### PR TITLE
docs: improve .github/copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,82 +1,74 @@
 <!-- Use this file to provide workspace-specific custom instructions to Copilot. For more details, visit https://code.visualstudio.com/docs/copilot/copilot-customization#_use-a-githubcopilotinstructionsmd-file -->
 
-# Unity Package Wrapper Project Instructions
+# Unity Package Wrapper
 
-This is a Python project that automatically builds Unity packages from open source repositories and publishes them to GitHub's package registry.
+Python tool that automatically wraps open-source C# libraries into Unity Package Manager (UPM) packages and publishes them to a registry.
 
-## Project Structure
+## Commands
 
-- `src/unity_wrapper/` - Main Python package
-- `config/` - Configuration files (packages.yaml, settings.yaml)
-- `templates/` - Jinja2 templates for Unity files
-- `packages/` - Generated Unity packages (output directory)
-- `tests/` - Test suite
+```bash
+# Setup
+make dev-setup          # Full dev setup: install deps, config, pre-commit hooks
+poetry install --with dev
 
-## Key Components
+# Testing
+make test               # Run full test suite with coverage
+poetry run pytest tests/test_unity_generator.py -v   # Single test file
+poetry run pytest tests/ -k "test_organize_runtime"  # Single test by name
 
-### Core Modules
-- `GitManager` - Handles Git repository operations and ref tracking
-- `UnityGenerator` - Generates Unity-specific files (package.json, .asmdef, .meta)
-- `PackageBuilder` - Main orchestrator for the package building process
-- `ConfigManager` - Manages YAML configuration files
+# Quality
+make lint               # black --check + flake8 + mypy
+make format             # Auto-format with black
+make qa                 # format + lint + test
 
-### Utilities
-- `FileWatcher` - Monitors configuration changes for automatic rebuilds
-- `GitHubPublisher` - Publishes packages to GitHub Package Registry
+# Package operations (CLI)
+poetry run unity-wrapper build                       # Build all packages
+poetry run unity-wrapper build com.example.pkg       # Build one package
+poetry run unity-wrapper check                       # Check which need updates
+poetry run unity-wrapper publish --registry github --owner <org>
+poetry run unity-wrapper watch                       # Auto-rebuild on config change
 
-## Unity Package Structure
-
-Generated packages follow Unity Package Manager conventions:
-```
-package_name/
-├── package.json         # Unity package manifest
-├── Runtime/            # Runtime code and assets
-│   ├── *.cs           # C# source files
-│   ├── *.asmdef       # Assembly definition
-│   └── *.meta         # Unity meta files
-└── *.meta             # Meta files for all directories
+# Makefile shortcuts
+make build-package PACKAGE=com.example.pkg
+make publish REGISTRY=github OWNER=myorg
 ```
 
-## Configuration
+## Architecture
 
-### packages.yaml
-Defines source repositories and package settings:
-- Git repository URL and ref
-- Extract path within repository
-- C# namespace and assembly definition settings
-- Unity package metadata
+`PackageBuilder` is the top-level orchestrator used as a context manager. It wires together:
+- `ConfigManager` — reads `config/packages.yaml` and `config/settings.yaml`
+- `GitManager` — clones/updates source repos into `.unity_wrapper_temp/`
+- `NuGetManager` — downloads `.nupkg` files from nuget.org for NuGet-sourced packages
+- `UnityGenerator` — produces all Unity-specific output files using Jinja2 templates from `templates/`
+- `PackagePublisher` / `GitHubPublisher` — publishes via npm CLI (npm must be installed)
 
-### settings.yaml
-Global settings for the wrapper:
-- Output directories
-- GitHub registry configuration
-- Default package settings
+**Two package source types** are supported in `config/packages.yaml`:
+- `source.type: git` — clones a repo, extracts `extract_path` subtree into `Runtime/`
+- `source.type: nuget` — downloads NuGet package, extracts DLLs for the target framework
 
-## Development Guidelines
+The `PackageBuilder` determines type via `ConfigManager.get_package_type()`, which checks `packages` (git) vs `nuget_packages` (separate top-level key) in packages.yaml.
 
-- Use type hints for all function parameters and return values
-- Follow Unity Package Manager naming conventions (com.company.package)
-- Generate .meta files for all Unity assets and directories
-- Support Git refs (branches, tags, commit hashes)
-- Implement proper error handling for Git operations
-- Use structured logging for debugging
+**Publishing** uses the npm registry protocol. `PackagePublisher` wraps `npm publish` with a generated `.npmrc`; supported registries are `github`, `npmjs`, and `openupm`. Auth tokens are read from `GITHUB_TOKEN` / `NPM_TOKEN` env vars or `config/settings.yaml`.
 
-## Unity Conventions
+## Key Conventions
 
-- Package names use reverse domain notation (com.example.package)
-- Runtime code goes in Runtime/ folder
-- Assembly definitions have root namespace matching the package
-- All files and folders need corresponding .meta files
-- package.json follows Unity Package Manager schema
+**Meta file generation**: Every file and directory in a generated package must have a corresponding `.meta` file with a stable GUID. `UnityGenerator` generates these automatically; never copy files into the output without going through `UnityGenerator`.
 
-## Python Code Style Guide
-This document outlines the coding style and conventions for Python code in the Unity Package Wrapper project. It is designed to ensure consistency, readability, and maintainability across the codebase.
-- Use PEP 8 style guide for Python code
-- Use type hints for all function parameters and return values
-- Follow consistent naming conventions (snake_case for variables and functions, CamelCase for classes)
-- Use docstrings for all public functions and classes
-- Use f-strings for string formatting (Python 3.6+)
-- Keep line length to a maximum of 79 characters
-- Use spaces around operators and after commas
-- Use 4 spaces for indentation (no tabs)
-- Use `flake8` for linting and `black` for formatting. Perform these checks before committing code.
+**Runtime folder logic**: If the source already contains a `Runtime/` directory, it is used as-is. Otherwise all source files are placed under a new `Runtime/` folder. This logic lives in `UnityGenerator.organize_runtime_structure()`.
+
+**Assembly definitions**: Generated `.asmdef` files use `asmdef_name` as the assembly name and `namespace` as `rootNamespace`. Extra fields (e.g., `allowUnsafeCode: true`) are injected via `asmdef_extra` in packages.yaml.
+
+**`package.json` extras**: Arbitrary UPM manifest fields can be added per-package using `package_json_extra` in packages.yaml (e.g., `license`, `homepage`).
+
+**`assembly_references`**: Optional list in packages.yaml for adding cross-assembly references to the `.asmdef` (e.g., `["UniTask"]`).
+
+**Work directory**: `.unity_wrapper_temp/` is a throwaway scratch space for git clones and NuGet downloads. It is cleaned up when `PackageBuilder` exits its context. Do not persist data there.
+
+## Code Style
+
+- Python 3.10+, `src/` layout (`src/unity_wrapper/`)
+- Type hints required on all public functions; `mypy` enforced in CI
+- Line length: 79 characters (`black` + `flake8`)
+- Docstrings on all public classes and methods
+- `logging` (not `print`) for all diagnostic output; module-level `logger = logging.getLogger(__name__)`
+- Pre-commit hooks enforce formatting/linting before each commit (`make install-hooks`)


### PR DESCRIPTION
Rewrites the Copilot instructions file to focus on actionable, non-obvious information:

- **Build/test/lint commands** — full `make` and `poetry run` commands including how to run a single test by file or name
- **Architecture flow** — how the 5 core classes connect, that `PackageBuilder` is a context manager, and the two source types (git vs NuGet)
- **Publishing prerequisite** — npm CLI must be installed (not documented elsewhere)
- **Non-obvious conventions** — meta file invariant, Runtime folder detection logic, `asmdef_extra`/`package_json_extra`/`assembly_references` escape hatches in packages.yaml, work dir lifecycle
- **`mypy` enforcement** — was missing from the original

Removes generic advice ("write docstrings", "use meaningful names") already obvious to any developer.