### PR TITLE
feat: parallel git clones with persistent cache

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,7 +37,7 @@ make publish REGISTRY=github OWNER=myorg
 
 `PackageBuilder` is the top-level orchestrator used as a context manager. It wires together:
 - `ConfigManager` — reads `config/packages.yaml` and `config/settings.yaml`
-- `GitManager` — clones/updates source repos into `.unity_wrapper_temp/`
+- `GitManager` — clones/updates source repos; supports a persistent `cache_dir` (default `.git-cache/`) and parallel prefetch via `prefetch_all()`
 - `NuGetManager` — downloads `.nupkg` files from nuget.org for NuGet-sourced packages
 - `UnityGenerator` — produces all Unity-specific output files using Jinja2 templates from `templates/`
 - `PackagePublisher` / `GitHubPublisher` — publishes via npm CLI (npm must be installed)
@@ -62,7 +62,9 @@ The `PackageBuilder` determines type via `ConfigManager.get_package_type()`, whi
 
 **`assembly_references`**: Optional list in packages.yaml for adding cross-assembly references to the `.asmdef` (e.g., `["UniTask"]`).
 
-**Work directory**: `.unity_wrapper_temp/` is a throwaway scratch space for git clones and NuGet downloads. It is cleaned up when `PackageBuilder` exits its context. Do not persist data there.
+**Work directory**: `.unity_wrapper_temp/` is a throwaway scratch space for NuGet downloads and intermediate files. It is cleaned up when `PackageBuilder` exits its context. Do not persist data there.
+
+**Git clone cache**: `.git-cache/` is a *persistent* directory where `GitManager` stores git clones between builds. It is never deleted by `cleanup()`. Configure the path via `build.git_cache_dir` in `settings.yaml`. Parallel fetches are controlled by `build.max_parallel_clones` (default `4`). `build_all_packages()` runs a parallel prefetch phase before sequential Unity generation.
 
 ## Code Style
 

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ Thumbs.db
 
 # Unity Package Wrapper specific
 .unity_wrapper_temp/
+.git-cache/
 packages/
 *.log
 

--- a/src/unity_wrapper/core/config_manager.py
+++ b/src/unity_wrapper/core/config_manager.py
@@ -132,6 +132,19 @@ class ConfigManager:
         else:
             return self.config_path.parent / cast(str, work_dir)
 
+    def get_git_cache_dir(self) -> Path:
+        """Get persistent git clone cache directory."""
+        build = self.get_build_settings()
+        cache_dir = build.get("git_cache_dir", ".git-cache")
+        if Path(cache_dir).is_absolute():
+            return Path(cast(str, cache_dir))
+        return self.config_path.parent / cast(str, cache_dir)
+
+    def get_max_parallel_clones(self) -> int:
+        """Get maximum number of parallel git clone/fetch workers."""
+        build = self.get_build_settings()
+        return int(build.get("max_parallel_clones", 4))
+
     def get_github_settings(self) -> Dict[str, Any]:
         """Get GitHub publishing settings."""
         return cast(Dict[str, Any], self.settings_config.get("github", {}))

--- a/src/unity_wrapper/core/config_manager.py
+++ b/src/unity_wrapper/core/config_manager.py
@@ -143,7 +143,20 @@ class ConfigManager:
     def get_max_parallel_clones(self) -> int:
         """Get maximum number of parallel git clone/fetch workers."""
         build = self.get_build_settings()
-        return int(build.get("max_parallel_clones", 4))
+        raw = build.get("max_parallel_clones", 4)
+        try:
+            value = int(raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Invalid value for build.max_parallel_clones: {raw!r}."
+                " Must be a positive integer."
+            ) from exc
+        if value <= 0:
+            raise ValueError(
+                f"Invalid value for build.max_parallel_clones: {value!r}."
+                " Must be a positive integer."
+            )
+        return value
 
     def get_github_settings(self) -> Dict[str, Any]:
         """Get GitHub publishing settings."""

--- a/src/unity_wrapper/core/git_manager.py
+++ b/src/unity_wrapper/core/git_manager.py
@@ -52,6 +52,14 @@ class GitManager:
                     self._checkout_ref(repo, ref)
                 else:
                     logger.info(f"Repository {name} already at ref {ref}")
+                    # For branch refs, fast-forward to the latest remote
+                    # commit that was just fetched.  Tags and commit hashes
+                    # cannot be fast-forwarded, so failures are silenced.
+                    try:
+                        repo.git.reset("--hard", f"origin/{ref}")
+                        logger.debug(f"Fast-forwarded {name} to origin/{ref}")
+                    except GitCommandError:
+                        pass
 
                 self.repos[name] = repo
                 return repo_path
@@ -102,7 +110,7 @@ class GitManager:
                     errors[repo_name] = exc
 
         if errors:
-            failed = ", ".join(errors.keys())
+            failed = ", ".join(sorted(errors.keys()))
             raise RuntimeError(
                 f"Failed to fetch {len(errors)} repo(s): {failed}"
             )
@@ -184,8 +192,38 @@ class GitManager:
         for _, repo in self.repos.items():
             repo.close()
 
-        if self.work_dir != self.cache_dir and self.work_dir.exists():
-            shutil.rmtree(self.work_dir)
+        work_dir = self.work_dir.resolve()
+        cache_dir = self.cache_dir.resolve()
+
+        if not work_dir.exists():
+            logger.info(
+                "Temporary working directory does not exist; nothing to clean"
+            )
+            return
+
+        if work_dir == cache_dir:
+            logger.info(
+                "Temporary working directory is the git cache; nothing removed"
+            )
+            return
+
+        # Cache is nested inside work_dir: remove everything except the cache.
+        if cache_dir.is_relative_to(work_dir):
+            for entry in work_dir.iterdir():
+                if entry.resolve() == cache_dir:
+                    continue
+                if entry.is_dir():
+                    shutil.rmtree(entry)
+                else:
+                    entry.unlink()
+            logger.info(
+                "Cleaned up temporary working directory contents"
+                " (git cache preserved)"
+            )
+            return
+
+        # Cache is outside work_dir: safe to remove the whole directory.
+        shutil.rmtree(work_dir)
         logger.info(
             "Cleaned up temporary working directory (git cache preserved)"
         )

--- a/src/unity_wrapper/core/git_manager.py
+++ b/src/unity_wrapper/core/git_manager.py
@@ -2,8 +2,9 @@
 
 import shutil
 import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 from git import Repo, GitCommandError
 
 
@@ -13,15 +14,24 @@ logger = logging.getLogger(__name__)
 class GitManager:
     """Manages Git repositories for Unity package building."""
 
-    def __init__(self, work_dir: Path):
-        """Initialize GitManager with working directory."""
+    def __init__(self, work_dir: Path, cache_dir: Optional[Path] = None):
+        """Initialize GitManager with working and optional cache directories.
+
+        Args:
+            work_dir: Temporary working directory, cleaned up after use.
+            cache_dir: Persistent directory for git clones. When provided,
+                clones are stored here and survive between builds. Defaults
+                to work_dir when not specified.
+        """
         self.work_dir = Path(work_dir)
         self.work_dir.mkdir(parents=True, exist_ok=True)
+        self.cache_dir = Path(cache_dir) if cache_dir else self.work_dir
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
         self.repos: Dict[str, Repo] = {}
 
     def clone_or_update(self, url: str, ref: str, name: str) -> Path:
         """Clone or update a repository to the specified ref."""
-        repo_path = self.work_dir / name
+        repo_path = self.cache_dir / name
 
         try:
             if repo_path.exists():
@@ -36,25 +46,66 @@ class GitManager:
                 current_ref = self._get_current_ref(repo)
                 if current_ref != ref:
                     logger.info(
-                        f"Ref changed from {current_ref} to {ref}, updating..."
+                        f"Ref changed from {current_ref} to {ref},"
+                        " updating..."
                     )
                     self._checkout_ref(repo, ref)
-                    return repo_path
                 else:
                     logger.info(f"Repository {name} already at ref {ref}")
-                    return repo_path
+
+                self.repos[name] = repo
+                return repo_path
             else:
                 # Clone new repository
                 logger.info(f"Cloning repository: {url}")
                 repo = Repo.clone_from(url, repo_path)
                 self._checkout_ref(repo, ref)
-
-            self.repos[name] = repo
-            return repo_path
+                self.repos[name] = repo
+                return repo_path
 
         except GitCommandError as e:
             logger.error(f"Git operation failed for {name}: {e}")
             raise
+
+    def prefetch_all(
+        self,
+        repos: List[Dict[str, str]],
+        max_workers: int = 4,
+    ) -> None:
+        """Clone or update all repositories in parallel.
+
+        Args:
+            repos: List of dicts with keys ``url``, ``ref``, and ``name``.
+            max_workers: Maximum number of concurrent git operations.
+
+        Raises:
+            RuntimeError: If one or more repos fail, after all have been
+                attempted.
+        """
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {
+                executor.submit(
+                    self.clone_or_update,
+                    r["url"],
+                    r["ref"],
+                    r["name"],
+                ): r["name"]
+                for r in repos
+            }
+            errors: Dict[str, Exception] = {}
+            for future in as_completed(futures):
+                repo_name = futures[future]
+                try:
+                    future.result()
+                except Exception as exc:
+                    logger.error(f"Failed to fetch repo '{repo_name}': {exc}")
+                    errors[repo_name] = exc
+
+        if errors:
+            failed = ", ".join(errors.keys())
+            raise RuntimeError(
+                f"Failed to fetch {len(errors)} repo(s): {failed}"
+            )
 
     def _checkout_ref(self, repo: Repo, ref: str) -> None:
         """Checkout a specific ref (branch, tag, or commit)."""
@@ -110,7 +161,7 @@ class GitManager:
         if repo_name not in self.repos:
             raise ValueError(f"Repository {repo_name} not found")
 
-        repo_path = self.work_dir / repo_name
+        repo_path = self.cache_dir / repo_name
         source_full_path = repo_path / source_path
 
         if not source_full_path.exists():
@@ -129,10 +180,12 @@ class GitManager:
         )
 
     def cleanup(self) -> None:
-        """Clean up temporary repositories."""
+        """Clean up temporary working directory; preserve the cache."""
         for _, repo in self.repos.items():
             repo.close()
 
-        if self.work_dir.exists():
+        if self.work_dir != self.cache_dir and self.work_dir.exists():
             shutil.rmtree(self.work_dir)
-        logger.info("Cleaned up temporary repositories")
+        logger.info(
+            "Cleaned up temporary working directory (git cache preserved)"
+        )

--- a/src/unity_wrapper/core/package_builder.py
+++ b/src/unity_wrapper/core/package_builder.py
@@ -30,7 +30,8 @@ class PackageBuilder:
 
         # Set up working directory for git operations
         self.work_dir = work_dir or (Path.cwd() / ".unity_wrapper_temp")
-        self.git_manager = GitManager(self.work_dir)
+        cache_dir = self.config.get_git_cache_dir()
+        self.git_manager = GitManager(self.work_dir, cache_dir=cache_dir)
 
         # Set up NuGet manager
         self.nuget_manager = NuGetManager(self.work_dir / "nuget")
@@ -190,10 +191,38 @@ class PackageBuilder:
         return package_output_dir
 
     def build_all_packages(self) -> List[Path]:
-        """Build all configured packages."""
-        package_names = self.config.get_all_package_names()
-        built_packages: List[Path] = []
+        """Build all configured packages.
 
+        Git repositories are fetched in parallel before Unity package
+        generation begins, reducing total build time significantly.
+        """
+        package_names = self.config.get_all_package_names()
+        max_workers = self.config.get_max_parallel_clones()
+
+        # Phase 1: fetch all git repos in parallel
+        git_repos = []
+        for name in package_names:
+            if self.config.get_package_type(name) != "git":
+                continue
+            pkg_cfg = self.config.get_package_config(name)
+            if pkg_cfg:
+                git_repos.append(
+                    {
+                        "url": pkg_cfg["source"]["url"],
+                        "ref": pkg_cfg["source"]["ref"],
+                        "name": name,
+                    }
+                )
+
+        if git_repos:
+            logger.info(
+                f"Prefetching {len(git_repos)} git repo(s) with"
+                f" max_workers={max_workers}"
+            )
+            self.git_manager.prefetch_all(git_repos, max_workers=max_workers)
+
+        # Phase 2: generate Unity packages sequentially
+        built_packages: List[Path] = []
         for package_name in package_names:
             try:
                 package_path = self.build_package(package_name)

--- a/src/unity_wrapper/core/package_builder.py
+++ b/src/unity_wrapper/core/package_builder.py
@@ -68,12 +68,15 @@ class PackageBuilder:
         source_config = package_config["source"]
         extract_path = package_config.get("extract_path", ".")
 
-        # Clone or update repository
-        repo_path = self.git_manager.clone_or_update(
-            url=source_config["url"],
-            ref=source_config["ref"],
-            name=package_name,
-        )
+        # Clone or update repository (skip if already prefetched)
+        if package_name in self.git_manager.repos:
+            repo_path = self.git_manager.cache_dir / package_name
+        else:
+            repo_path = self.git_manager.clone_or_update(
+                url=source_config["url"],
+                ref=source_config["ref"],
+                name=package_name,
+            )
 
         # Create package output directory
         package_output_dir = self.output_dir / package_name
@@ -264,7 +267,7 @@ class PackageBuilder:
         source_config = package_config["source"]
 
         # Check if repository exists and if ref has changed
-        repo_path = self.work_dir / package_name
+        repo_path = self.git_manager.cache_dir / package_name
         if repo_path.exists():
             current_info = self.git_manager.get_repo_info(package_name)
             if current_info and current_info["ref"] != source_config["ref"]:

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -140,3 +140,35 @@ def test_get_max_parallel_clones_custom(temp_config_dir: Path) -> None:
 
     config = ConfigManager(temp_config_dir)
     assert config.get_max_parallel_clones() == 8
+
+
+def test_get_max_parallel_clones_invalid_type(temp_config_dir: Path) -> None:
+    """get_max_parallel_clones raises ValueError for a non-integer value."""
+    settings_path = temp_config_dir / "settings.yaml"
+    with open(settings_path) as f:
+        import yaml
+
+        data = yaml.safe_load(f)
+    data.setdefault("build", {})["max_parallel_clones"] = "fast"
+    with open(settings_path, "w") as f:
+        yaml.dump(data, f)
+
+    config = ConfigManager(temp_config_dir)
+    with pytest.raises(ValueError, match="max_parallel_clones"):
+        config.get_max_parallel_clones()
+
+
+def test_get_max_parallel_clones_zero_raises(temp_config_dir: Path) -> None:
+    """get_max_parallel_clones raises ValueError when value is 0."""
+    settings_path = temp_config_dir / "settings.yaml"
+    with open(settings_path) as f:
+        import yaml
+
+        data = yaml.safe_load(f)
+    data.setdefault("build", {})["max_parallel_clones"] = 0
+    with open(settings_path, "w") as f:
+        yaml.dump(data, f)
+
+    config = ConfigManager(temp_config_dir)
+    with pytest.raises(ValueError, match="max_parallel_clones"):
+        config.get_max_parallel_clones()

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -97,3 +97,46 @@ def test_config_manager_add_remove_package(temp_config_dir: Path) -> None:
     # Try to remove non-existent package
     success = config.remove_package("com.test.nonexistent")
     assert success is False
+
+
+def test_get_git_cache_dir_default(temp_config_dir: Path) -> None:
+    """get_git_cache_dir returns default when not in settings."""
+    config = ConfigManager(temp_config_dir)
+    cache_dir = config.get_git_cache_dir()
+    assert cache_dir == temp_config_dir.parent / ".git-cache"
+
+
+def test_get_git_cache_dir_custom(temp_config_dir: Path) -> None:
+    """get_git_cache_dir respects a custom value in settings.yaml."""
+    settings_path = temp_config_dir / "settings.yaml"
+    with open(settings_path) as f:
+        import yaml
+
+        data = yaml.safe_load(f)
+    data.setdefault("build", {})["git_cache_dir"] = "my-cache"
+    with open(settings_path, "w") as f:
+        yaml.dump(data, f)
+
+    config = ConfigManager(temp_config_dir)
+    assert config.get_git_cache_dir() == temp_config_dir.parent / "my-cache"
+
+
+def test_get_max_parallel_clones_default(temp_config_dir: Path) -> None:
+    """get_max_parallel_clones returns 4 when not in settings."""
+    config = ConfigManager(temp_config_dir)
+    assert config.get_max_parallel_clones() == 4
+
+
+def test_get_max_parallel_clones_custom(temp_config_dir: Path) -> None:
+    """get_max_parallel_clones respects a custom value in settings.yaml."""
+    settings_path = temp_config_dir / "settings.yaml"
+    with open(settings_path) as f:
+        import yaml
+
+        data = yaml.safe_load(f)
+    data.setdefault("build", {})["max_parallel_clones"] = 8
+    with open(settings_path, "w") as f:
+        yaml.dump(data, f)
+
+    config = ConfigManager(temp_config_dir)
+    assert config.get_max_parallel_clones() == 8

--- a/tests/test_git_manager.py
+++ b/tests/test_git_manager.py
@@ -129,6 +129,27 @@ class TestCleanup:
         # The shared dir must NOT be removed (cache takes precedence)
         assert work_dir.exists()
 
+    def test_cleanup_cache_nested_inside_work_dir(
+        self, temp_dirs: tuple[Path, Path]
+    ) -> None:
+        """When cache nested in work_dir, only non-cache contents removed."""
+        work_dir, _ = temp_dirs
+        cache_dir = work_dir / ".git-cache"
+        cache_dir.mkdir(parents=True)
+        gm = GitManager(work_dir, cache_dir=cache_dir)
+
+        (work_dir / "tmp.txt").write_text("tmp")
+        (work_dir / "scratch").mkdir()
+        (cache_dir / "myrepo").mkdir()
+
+        gm.cleanup()
+
+        assert work_dir.exists()
+        assert cache_dir.exists()
+        assert (cache_dir / "myrepo").exists()
+        assert not (work_dir / "tmp.txt").exists()
+        assert not (work_dir / "scratch").exists()
+
 
 class TestPrefetchAll:
     """prefetch_all parallelises clone_or_update calls."""
@@ -168,14 +189,15 @@ class TestPrefetchAll:
             with patch(
                 "unity_wrapper.core.git_manager.ThreadPoolExecutor"
             ) as mock_tpe:
-                mock_tpe.return_value.__enter__ = lambda s: MagicMock(
-                    submit=lambda fn, *a, **kw: _immediate_future(fn(*a, **kw))
+                executor_mock = MagicMock()
+                executor_mock.submit.side_effect = (
+                    lambda fn, *a, **kw: _immediate_future(fn(*a, **kw))
                 )
+                mock_tpe.return_value.__enter__.return_value = executor_mock
                 mock_tpe.return_value.__exit__ = MagicMock(return_value=False)
-                try:
-                    gm.prefetch_all(repos, max_workers=7)
-                except Exception:
-                    pass
+
+                gm.prefetch_all(repos, max_workers=7)
+
                 mock_tpe.assert_called_once_with(max_workers=7)
 
     def test_errors_are_aggregated_not_aborted(
@@ -197,6 +219,21 @@ class TestPrefetchAll:
                 gm.prefetch_all(repos, max_workers=4)
 
         assert len(attempted) == 3
+
+    def test_error_message_lists_repos_in_sorted_order(
+        self, temp_dirs: tuple[Path, Path]
+    ) -> None:
+        """Failed repo names appear sorted in the RuntimeError message."""
+        work_dir, cache_dir = temp_dirs
+        gm = GitManager(work_dir, cache_dir=cache_dir)
+        repos = self._make_repos(3)
+
+        def side_effect(url: str, ref: str, name: str) -> None:
+            raise RuntimeError("bang")
+
+        with patch.object(gm, "clone_or_update", side_effect=side_effect):
+            with pytest.raises(RuntimeError, match="repo0, repo1, repo2"):
+                gm.prefetch_all(repos, max_workers=4)
 
     def test_empty_repo_list_is_a_noop(
         self, temp_dirs: tuple[Path, Path]

--- a/tests/test_git_manager.py
+++ b/tests/test_git_manager.py
@@ -1,0 +1,214 @@
+"""Tests for GitManager parallel fetching and persistent cache behaviour."""
+
+import pytest
+import tempfile
+from concurrent.futures import Future
+from pathlib import Path
+from typing import Any, Dict, Generator, List
+from unittest.mock import MagicMock, patch
+
+from unity_wrapper.core.git_manager import GitManager
+
+
+@pytest.fixture
+def temp_dirs() -> Generator[tuple[Path, Path], None, None]:
+    """Provide separate work_dir and cache_dir in a temp location."""
+    with tempfile.TemporaryDirectory() as tmp:
+        base = Path(tmp)
+        yield base / "work", base / "cache"
+
+
+class TestCacheDir:
+    """GitManager uses cache_dir for clones; work_dir is separate."""
+
+    def test_cache_dir_defaults_to_work_dir(
+        self, temp_dirs: tuple[Path, Path]
+    ) -> None:
+        """When cache_dir is omitted, it falls back to work_dir."""
+        work_dir, _ = temp_dirs
+        gm = GitManager(work_dir)
+        assert gm.cache_dir == gm.work_dir
+
+    def test_explicit_cache_dir_is_used(
+        self, temp_dirs: tuple[Path, Path]
+    ) -> None:
+        """Explicit cache_dir is stored separately from work_dir."""
+        work_dir, cache_dir = temp_dirs
+        gm = GitManager(work_dir, cache_dir=cache_dir)
+        assert gm.cache_dir == cache_dir
+        assert gm.work_dir != gm.cache_dir
+
+    def test_cache_dir_is_created(self, temp_dirs: tuple[Path, Path]) -> None:
+        """Both directories are created on init."""
+        work_dir, cache_dir = temp_dirs
+        GitManager(work_dir, cache_dir=cache_dir)
+        assert work_dir.exists()
+        assert cache_dir.exists()
+
+
+class TestCloneOrUpdateRegistersRepo:
+    """clone_or_update always registers the repo in self.repos."""
+
+    def test_fresh_clone_registers_repo(
+        self, temp_dirs: tuple[Path, Path]
+    ) -> None:
+        """A freshly cloned repo is added to self.repos."""
+        work_dir, cache_dir = temp_dirs
+        gm = GitManager(work_dir, cache_dir=cache_dir)
+
+        mock_repo = MagicMock()
+        with patch(
+            "unity_wrapper.core.git_manager.Repo.clone_from",
+            return_value=mock_repo,
+        ):
+            gm.clone_or_update(
+                "https://example.com/repo.git", "main", "myrepo"
+            )
+
+        assert "myrepo" in gm.repos
+        assert gm.repos["myrepo"] is mock_repo
+
+    def test_existing_repo_update_registers_repo(
+        self, temp_dirs: tuple[Path, Path]
+    ) -> None:
+        """Updating an existing repo still registers it in self.repos."""
+        work_dir, cache_dir = temp_dirs
+        gm = GitManager(work_dir, cache_dir=cache_dir)
+
+        # Pre-create the repo path to simulate an existing clone
+        repo_path = cache_dir / "myrepo"
+        repo_path.mkdir(parents=True)
+
+        mock_remote = MagicMock()
+        mock_repo = MagicMock()
+        mock_repo.remotes.origin = mock_remote
+        mock_repo.active_branch.name = "main"
+
+        with patch(
+            "unity_wrapper.core.git_manager.Repo",
+            return_value=mock_repo,
+        ):
+            gm.clone_or_update(
+                "https://example.com/repo.git", "main", "myrepo"
+            )
+
+        assert "myrepo" in gm.repos
+        assert gm.repos["myrepo"] is mock_repo
+
+
+class TestCleanup:
+    """cleanup() preserves cache_dir and only removes work_dir."""
+
+    def test_cleanup_removes_work_dir_not_cache(
+        self, temp_dirs: tuple[Path, Path]
+    ) -> None:
+        """cleanup() deletes work_dir but leaves cache_dir intact."""
+        work_dir, cache_dir = temp_dirs
+        gm = GitManager(work_dir, cache_dir=cache_dir)
+
+        # Add a dummy file so the dirs definitely exist
+        (work_dir / "tmp.txt").write_text("tmp")
+        (cache_dir / "cached_repo").mkdir()
+
+        gm.cleanup()
+
+        assert not work_dir.exists()
+        assert cache_dir.exists()
+        assert (cache_dir / "cached_repo").exists()
+
+    def test_cleanup_when_cache_equals_work_dir(
+        self, temp_dirs: tuple[Path, Path]
+    ) -> None:
+        """When cache_dir == work_dir, cleanup does NOT delete it."""
+        work_dir, _ = temp_dirs
+        gm = GitManager(work_dir)  # cache_dir defaults to work_dir
+
+        (work_dir / "something").mkdir()
+        gm.cleanup()
+
+        # The shared dir must NOT be removed (cache takes precedence)
+        assert work_dir.exists()
+
+
+class TestPrefetchAll:
+    """prefetch_all parallelises clone_or_update calls."""
+
+    def _make_repos(self, n: int = 3) -> List[Dict[str, str]]:
+        return [
+            {
+                "url": f"https://example.com/repo{i}.git",
+                "ref": "main",
+                "name": f"repo{i}",
+            }
+            for i in range(n)
+        ]
+
+    def test_all_repos_are_fetched(self, temp_dirs: tuple[Path, Path]) -> None:
+        """Every repo in the list has clone_or_update called."""
+        work_dir, cache_dir = temp_dirs
+        gm = GitManager(work_dir, cache_dir=cache_dir)
+        repos = self._make_repos(3)
+
+        with patch.object(gm, "clone_or_update") as mock_cu:
+            gm.prefetch_all(repos, max_workers=4)
+
+        assert mock_cu.call_count == 3
+        called_names = {c.args[2] for c in mock_cu.call_args_list}
+        assert called_names == {"repo0", "repo1", "repo2"}
+
+    def test_max_workers_is_respected(
+        self, temp_dirs: tuple[Path, Path]
+    ) -> None:
+        """ThreadPoolExecutor is created with the configured max_workers."""
+        work_dir, cache_dir = temp_dirs
+        gm = GitManager(work_dir, cache_dir=cache_dir)
+        repos = self._make_repos(2)
+
+        with patch.object(gm, "clone_or_update"):
+            with patch(
+                "unity_wrapper.core.git_manager.ThreadPoolExecutor"
+            ) as mock_tpe:
+                mock_tpe.return_value.__enter__ = lambda s: MagicMock(
+                    submit=lambda fn, *a, **kw: _immediate_future(fn(*a, **kw))
+                )
+                mock_tpe.return_value.__exit__ = MagicMock(return_value=False)
+                try:
+                    gm.prefetch_all(repos, max_workers=7)
+                except Exception:
+                    pass
+                mock_tpe.assert_called_once_with(max_workers=7)
+
+    def test_errors_are_aggregated_not_aborted(
+        self, temp_dirs: tuple[Path, Path]
+    ) -> None:
+        """All repos are attempted even if one fails; RuntimeError raised."""
+        work_dir, cache_dir = temp_dirs
+        gm = GitManager(work_dir, cache_dir=cache_dir)
+        repos = self._make_repos(3)
+        attempted: List[str] = []
+
+        def side_effect(url: str, ref: str, name: str) -> None:
+            attempted.append(name)
+            if name == "repo1":
+                raise RuntimeError("network error")
+
+        with patch.object(gm, "clone_or_update", side_effect=side_effect):
+            with pytest.raises(RuntimeError, match="Failed to fetch 1 repo"):
+                gm.prefetch_all(repos, max_workers=4)
+
+        assert len(attempted) == 3
+
+    def test_empty_repo_list_is_a_noop(
+        self, temp_dirs: tuple[Path, Path]
+    ) -> None:
+        """prefetch_all with an empty list completes without error."""
+        work_dir, cache_dir = temp_dirs
+        gm = GitManager(work_dir, cache_dir=cache_dir)
+        gm.prefetch_all([], max_workers=4)  # should not raise
+
+
+def _immediate_future(result: Any) -> Future:  # type: ignore[type-arg]
+    """Helper: return an already-resolved Future."""
+    f: Future[Any] = Future()
+    f.set_result(result)
+    return f

--- a/tests/test_package_builder.py
+++ b/tests/test_package_builder.py
@@ -1,0 +1,327 @@
+"""Tests for PackageBuilder.build_all_packages()."""
+
+import tempfile
+import yaml
+import pytest
+from pathlib import Path
+from typing import Any, Dict, Generator
+from unittest.mock import MagicMock, patch
+
+from unity_wrapper.core.package_builder import PackageBuilder
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+GIT_PKG = "com.test.gitpkg"
+NUGET_PKG = "com.test.nugetpkg"
+
+
+def _write_config(config_dir: Path, *, max_workers: int = 4) -> None:
+    packages: Dict[str, Any] = {
+        "packages": [
+            {
+                "name": GIT_PKG,
+                "source": {
+                    "url": "https://github.com/example/repo.git",
+                    "ref": "main",
+                },
+                "extract_path": "src",
+                "namespace": "Test",
+            }
+        ],
+        "nuget_packages": [
+            {
+                "name": NUGET_PKG,
+                "source": {
+                    "type": "nuget",
+                    "package": "Test.Package",
+                    "version": "1.0.0",
+                    "framework": "netstandard2.1",
+                },
+            }
+        ],
+    }
+    with open(config_dir / "packages.yaml", "w") as fh:
+        yaml.dump(packages, fh)
+
+    settings: Dict[str, Any] = {
+        "output_dir": "packages",
+        "work_dir": ".temp",
+        "build": {
+            "max_parallel_clones": max_workers,
+            "git_cache_dir": ".git-cache",
+        },
+    }
+    with open(config_dir / "settings.yaml", "w") as fh:
+        yaml.dump(settings, fh)
+
+
+def _write_git_only_config(config_dir: Path, *, max_workers: int = 4) -> None:
+    packages: Dict[str, Any] = {
+        "packages": [
+            {
+                "name": GIT_PKG,
+                "source": {
+                    "url": "https://github.com/example/repo.git",
+                    "ref": "main",
+                },
+                "extract_path": "src",
+            }
+        ]
+    }
+    with open(config_dir / "packages.yaml", "w") as fh:
+        yaml.dump(packages, fh)
+
+    settings: Dict[str, Any] = {"build": {"max_parallel_clones": max_workers}}
+    with open(config_dir / "settings.yaml", "w") as fh:
+        yaml.dump(settings, fh)
+
+
+def _write_nuget_only_config(config_dir: Path) -> None:
+    packages: Dict[str, Any] = {
+        "nuget_packages": [
+            {
+                "name": NUGET_PKG,
+                "source": {
+                    "type": "nuget",
+                    "package": "Test.Package",
+                    "version": "1.0.0",
+                    "framework": "netstandard2.1",
+                },
+            }
+        ]
+    }
+    with open(config_dir / "packages.yaml", "w") as fh:
+        yaml.dump(packages, fh)
+
+    with open(config_dir / "settings.yaml", "w") as fh:
+        yaml.dump({}, fh)
+
+
+def _write_empty_config(config_dir: Path) -> None:
+    with open(config_dir / "packages.yaml", "w") as fh:
+        yaml.dump({}, fh)
+    with open(config_dir / "settings.yaml", "w") as fh:
+        yaml.dump({}, fh)
+
+
+@pytest.fixture
+def tmp_dirs() -> Generator[tuple[Path, Path], None, None]:
+    with tempfile.TemporaryDirectory() as tmp:
+        base = Path(tmp)
+        yield base / "config", base / "output"
+
+
+def _make_builder(
+    config_dir: Path, output_dir: Path
+) -> tuple["PackageBuilder", MagicMock, MagicMock]:
+    """Construct a PackageBuilder with heavy collaborators patched out.
+
+    Returns (builder, mock_git_manager_instance, mock_nuget_manager_instance).
+    """
+    with (
+        patch("unity_wrapper.core.package_builder.GitManager") as MockGitMgr,
+        patch(
+            "unity_wrapper.core.package_builder.NuGetManager"
+        ) as MockNugetMgr,
+        patch("unity_wrapper.core.package_builder.UnityGenerator"),
+    ):
+        mock_git = MockGitMgr.return_value
+        mock_git.repos = {}
+        mock_git.cache_dir = config_dir / ".git-cache"
+        mock_nuget = MockNugetMgr.return_value
+
+        builder = PackageBuilder(config_dir, output_dir)
+        # Re-assign so the instance attributes point to our mocks
+        builder.git_manager = mock_git
+        builder.nuget_manager = mock_nuget
+
+    return builder, mock_git, mock_nuget
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAllPackages:
+    """Unit tests for PackageBuilder.build_all_packages()."""
+
+    def test_prefetch_called_only_for_git_packages(
+        self, tmp_dirs: tuple[Path, Path]
+    ) -> None:
+        """prefetch_all receives only git repos, not NuGet packages."""
+        config_dir, output_dir = tmp_dirs
+        config_dir.mkdir(parents=True)
+        _write_config(config_dir)
+
+        builder, mock_git, _ = _make_builder(config_dir, output_dir)
+        expected_path = output_dir / GIT_PKG
+
+        with patch.object(
+            builder, "build_package", return_value=expected_path
+        ):
+            builder.build_all_packages()
+
+        mock_git.prefetch_all.assert_called_once()
+        repos_arg = mock_git.prefetch_all.call_args.args[0]
+        names = [r["name"] for r in repos_arg]
+        assert names == [GIT_PKG]
+        assert NUGET_PKG not in names
+
+    def test_max_workers_passed_to_prefetch(
+        self, tmp_dirs: tuple[Path, Path]
+    ) -> None:
+        """max_workers from config is forwarded to prefetch_all."""
+        config_dir, output_dir = tmp_dirs
+        config_dir.mkdir(parents=True)
+        _write_git_only_config(config_dir, max_workers=8)
+
+        builder, mock_git, _ = _make_builder(config_dir, output_dir)
+
+        with patch.object(
+            builder, "build_package", return_value=output_dir / GIT_PKG
+        ):
+            builder.build_all_packages()
+
+        mock_git.prefetch_all.assert_called_once()
+        assert mock_git.prefetch_all.call_args.kwargs["max_workers"] == 8
+
+    def test_build_package_called_for_every_package(
+        self, tmp_dirs: tuple[Path, Path]
+    ) -> None:
+        """build_package is called once per configured package."""
+        config_dir, output_dir = tmp_dirs
+        config_dir.mkdir(parents=True)
+        _write_config(config_dir)
+
+        builder, _, _ = _make_builder(config_dir, output_dir)
+
+        with patch.object(
+            builder,
+            "build_package",
+            side_effect=lambda name: output_dir / name,
+        ) as mock_build:
+            builder.build_all_packages()
+
+        assert mock_build.call_count == 2
+        called_names = {c.args[0] for c in mock_build.call_args_list}
+        assert called_names == {GIT_PKG, NUGET_PKG}
+
+    def test_returns_all_built_paths(
+        self, tmp_dirs: tuple[Path, Path]
+    ) -> None:
+        """Return value is a list of every successfully built package path."""
+        config_dir, output_dir = tmp_dirs
+        config_dir.mkdir(parents=True)
+        _write_config(config_dir)
+
+        builder, _, _ = _make_builder(config_dir, output_dir)
+
+        with patch.object(
+            builder,
+            "build_package",
+            side_effect=lambda name: output_dir / name,
+        ):
+            result = builder.build_all_packages()
+
+        assert len(result) == 2
+        assert output_dir / GIT_PKG in result
+        assert output_dir / NUGET_PKG in result
+
+    def test_nuget_only_skips_prefetch(
+        self, tmp_dirs: tuple[Path, Path]
+    ) -> None:
+        """When there are no git packages, prefetch_all is never called."""
+        config_dir, output_dir = tmp_dirs
+        config_dir.mkdir(parents=True)
+        _write_nuget_only_config(config_dir)
+
+        builder, mock_git, _ = _make_builder(config_dir, output_dir)
+
+        with patch.object(
+            builder, "build_package", return_value=output_dir / NUGET_PKG
+        ):
+            builder.build_all_packages()
+
+        mock_git.prefetch_all.assert_not_called()
+
+    def test_empty_package_list_returns_empty(
+        self, tmp_dirs: tuple[Path, Path]
+    ) -> None:
+        """No packages configured → returns an empty list."""
+        config_dir, output_dir = tmp_dirs
+        config_dir.mkdir(parents=True)
+        _write_empty_config(config_dir)
+
+        builder, mock_git, _ = _make_builder(config_dir, output_dir)
+        result = builder.build_all_packages()
+
+        assert result == []
+        mock_git.prefetch_all.assert_not_called()
+
+    def test_build_failure_reraises(self, tmp_dirs: tuple[Path, Path]) -> None:
+        """build_package exception propagates out of build_all_packages."""
+        config_dir, output_dir = tmp_dirs
+        config_dir.mkdir(parents=True)
+        _write_git_only_config(config_dir)
+
+        builder, _, _ = _make_builder(config_dir, output_dir)
+
+        with patch.object(
+            builder, "build_package", side_effect=RuntimeError("build failed")
+        ):
+            with pytest.raises(RuntimeError, match="build failed"):
+                builder.build_all_packages()
+
+    def test_prefetch_repo_url_and_ref_are_correct(
+        self, tmp_dirs: tuple[Path, Path]
+    ) -> None:
+        """The url and ref forwarded to prefetch_all match packages.yaml."""
+        config_dir, output_dir = tmp_dirs
+        config_dir.mkdir(parents=True)
+        _write_git_only_config(config_dir)
+
+        builder, mock_git, _ = _make_builder(config_dir, output_dir)
+
+        with patch.object(
+            builder, "build_package", return_value=output_dir / GIT_PKG
+        ):
+            builder.build_all_packages()
+
+        repos_arg = mock_git.prefetch_all.call_args.args[0]
+        assert len(repos_arg) == 1
+        assert repos_arg[0]["url"] == "https://github.com/example/repo.git"
+        assert repos_arg[0]["ref"] == "main"
+        assert repos_arg[0]["name"] == GIT_PKG
+
+    def test_skips_clone_when_repo_already_prefetched(
+        self, tmp_dirs: tuple[Path, Path]
+    ) -> None:
+        """_build_git_package uses cached path when repo already prefetched."""
+        config_dir, output_dir = tmp_dirs
+        config_dir.mkdir(parents=True)
+        _write_git_only_config(config_dir)
+
+        builder, mock_git, _ = _make_builder(config_dir, output_dir)
+
+        # Simulate the repo having been prefetched already
+        mock_git.repos[GIT_PKG] = MagicMock()
+        repo_path = mock_git.cache_dir / GIT_PKG
+        repo_path.mkdir(parents=True)
+        (repo_path / "src").mkdir()
+
+        with (
+            patch.object(
+                builder.unity_generator, "organize_runtime_structure"
+            ) as mock_org,
+            patch.object(builder.unity_generator, "write_package_json"),
+            patch.object(builder.unity_generator, "generate_all_meta_files"),
+        ):
+            mock_org.return_value = output_dir / GIT_PKG / "Runtime"
+            builder._build_git_package(GIT_PKG)
+
+        # clone_or_update must NOT have been called
+        mock_git.clone_or_update.assert_not_called()


### PR DESCRIPTION
## Summary

Addresses the slow `make build` by parallelising git clone/fetch operations and persisting the clone cache between runs.

### Changes

**`GitManager`**
- New `cache_dir` parameter — repos are cloned into the persistent cache dir instead of the throwaway `work_dir`; `cleanup()` only removes `work_dir`, never `cache_dir`
- New `prefetch_all(repos, max_workers)` — fans out `clone_or_update()` via `ThreadPoolExecutor`; collects *all* errors before raising so every failure is visible at once
- **Bug fix**: `self.repos[name]` was only set on fresh clones, not on updates, so `extract_folder()` always raised `ValueError` for cached repos

**`ConfigManager`**
- `get_git_cache_dir()` — defaults to `.git-cache/`
- `get_max_parallel_clones()` — defaults to `4`

**`PackageBuilder`**
- Passes `cache_dir` from config to `GitManager`
- `build_all_packages()` runs a parallel prefetch phase for all git repos before the sequential Unity generation loop

**Config / housekeeping**
- `config/settings.yaml` template: new `build.git_cache_dir` and `build.max_parallel_clones` keys (file is gitignored; CI generates it from env vars)
- `.gitignore`: added `.git-cache/`

### Tests
- New `tests/test_git_manager.py`: cache dir init, repo registration bug fix, `cleanup()` preservation, `prefetch_all` parallelism + error aggregation
- Extended `tests/test_config_manager.py`: new getter defaults and custom values

All 61 tests pass; black + flake8 + mypy clean.