### PR TITLE
feat: log package URL after publish; suppress 409 version conflicts

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -113,7 +113,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: 'https://npm.pkg.github.com'
 
       - name: Create settings file for CI
         if: (steps.check-updates.outputs.updates-needed == 'true' || github.event.inputs.package_name != '') && github.ref == 'refs/heads/main'
@@ -127,7 +127,7 @@ jobs:
           output_dir: "packages"
           work_dir: ".unity_wrapper_temp"
 
-          # GitHub Package Registry settings (legacy, not used for npmjs)
+          # GitHub Package Registry settings
           github:
             owner: "${{ github.repository_owner }}"
             repository: "${{ github.event.repository.name }}"
@@ -148,13 +148,13 @@ jobs:
             fix_global_namespaces: true
           EOF
 
-      - name: Publish packages to npmjs.org
+      - name: Publish packages to GitHub Package Registry
         if: (steps.check-updates.outputs.updates-needed == 'true' || github.event.inputs.package_name != '') && github.ref == 'refs/heads/main'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Publishing packages to npmjs.org..."
-          make publish REGISTRY=npmjs OWNER=klumhru
+          echo "Publishing packages to GitHub Package Registry..."
+          make publish REGISTRY=github OWNER=${{ github.repository_owner }}
 
   test:
     runs-on: ubuntu-latest

--- a/src/unity_wrapper/cli.py
+++ b/src/unity_wrapper/cli.py
@@ -4,12 +4,11 @@ import click
 import logging
 import sys
 from pathlib import Path
-from typing import Optional, List, Dict, Any, Union
+from typing import Optional, List, Dict, Any
 
 from .core.package_builder import PackageBuilder
 from .core.config_manager import ConfigManager
 from .utils.file_watcher import FileWatcher
-from .utils.github_publisher import GitHubPublisher
 from .utils.package_publisher import create_publisher, PackagePublisher
 
 
@@ -173,51 +172,30 @@ def publish(
         # Determine owner
         final_owner = owner or github_settings.get("owner")
 
-        # Create appropriate publisher
-        publisher: Union[GitHubPublisher, PackagePublisher]
-        if registry == "github":
-            # Use provided token, or token from settings (if not empty),
-            # or None to let publisher use environment
-            settings_token = github_settings.get("token")
-            final_token = token or (settings_token if settings_token else None)
+        # Use provided token, or settings token (GitHub only), or let
+        # the publisher fall back to environment variables.
+        settings_token = github_settings.get("token")
+        final_token = token or (settings_token if settings_token else None)
 
-            try:
-                publisher = GitHubPublisher(
-                    token=final_token,
-                    registry_url=github_settings.get("registry_url"),
-                    owner=final_owner,
-                    repository=github_settings.get("repository"),
+        # Create publisher (handles all registries including GitHub)
+        publisher: PackagePublisher
+        try:
+            publisher = create_publisher(
+                registry=registry,
+                token=final_token,
+                owner=final_owner,
+            )
+        except RuntimeError as e:
+            if "npm is not available" in str(e):
+                click.echo(
+                    "Error: npm is required for publishing packages.\n"
+                    "Please install Node.js and npm from \n"
+                    "https://nodejs.org/",
+                    err=True,
                 )
-            except RuntimeError as e:
-                if "npm command not found" in str(e):
-                    click.echo(
-                        "Error: npm is required for publishing packages.\n"
-                        "Please install Node.js and npm from \n"
-                        "https://nodejs.org/",
-                        err=True,
-                    )
-                    sys.exit(1)
-                else:
-                    raise
-        else:
-            # Use new multi-registry publisher
-            try:
-                publisher = create_publisher(
-                    registry=registry,
-                    token=token,
-                    owner=final_owner,
-                )
-            except RuntimeError as e:
-                if "npm is not available" in str(e):
-                    click.echo(
-                        "Error: npm is required for publishing packages.\n"
-                        "Please install Node.js and npm from \n"
-                        "https://nodejs.org/",
-                        err=True,
-                    )
-                    sys.exit(1)
-                else:
-                    raise
+                sys.exit(1)
+            else:
+                raise
 
         if registry == "openupm":
             click.echo(

--- a/src/unity_wrapper/utils/package_publisher.py
+++ b/src/unity_wrapper/utils/package_publisher.py
@@ -56,6 +56,7 @@ class PackagePublisher:
         self.config = self.REGISTRY_CONFIGS[registry]
         self.token = token or self._get_token_from_env()
         self.owner = owner or self._get_owner_from_env()
+        self.repo = self._get_repo_from_env()
 
         # Check authentication requirements
         if self.config["requires_auth"] and not self.token:
@@ -84,6 +85,70 @@ class PackagePublisher:
         # Fall back to generic owner environment variable
         return os.getenv("PACKAGE_OWNER")
 
+    def _get_repo_from_env(self) -> Optional[str]:
+        """Get repository name from GITHUB_REPOSITORY env var."""
+        github_repo = os.getenv("GITHUB_REPOSITORY")
+        if github_repo and "/" in github_repo:
+            return github_repo.split("/", 1)[1]
+        return None
+
+    def _compute_scoped_name(self, name: str) -> str:
+        """Return the scoped package name for the current registry."""
+        if (
+            self.registry in ("github", "npmjs")
+            and self.owner
+            and not name.startswith("@")
+        ):
+            return f"@{self.owner}/{name}"
+        return name
+
+    def _package_browse_url(
+        self, scoped_name: str, original_name: str, version: str
+    ) -> str:
+        """Return a browser URL to inspect the published package.
+
+        Args:
+            scoped_name: Fully-scoped npm package name.
+            original_name: Unscoped Unity package name.
+            version: Package version string.
+
+        Returns:
+            Browser-accessible URL for the package.
+        """
+        if self.registry == "github":
+            if self.owner and self.repo:
+                pkg_slug = scoped_name.split("/")[-1]
+                return (
+                    f"https://github.com/{self.owner}/{self.repo}"
+                    f"/pkgs/npm/{pkg_slug}"
+                )
+            if self.owner:
+                return f"https://github.com/{self.owner}?tab=packages"
+            return "https://github.com"
+        if self.registry == "npmjs":
+            return (
+                f"https://www.npmjs.com/package/{scoped_name}" f"/v/{version}"
+            )
+        if self.registry == "openupm":
+            return f"https://openupm.com/packages/{original_name}/"
+        return ""
+
+    def _is_publish_conflict(
+        self, error: subprocess.CalledProcessError
+    ) -> bool:
+        """Return True if the error indicates a 409 version conflict."""
+        stderr = (error.stderr or "").lower()
+        return any(
+            indicator in stderr
+            for indicator in (
+                "e409",
+                "409 conflict",
+                "already exists",
+                "cannot publish over",
+                "epublishconflict",
+            )
+        )
+
     def _check_npm_available(self) -> None:
         """Check if npm is available."""
         try:
@@ -105,35 +170,44 @@ class PackagePublisher:
         if not package_json_path.exists():
             raise FileNotFoundError(f"package.json not found in {package_dir}")
 
-        # Load package.json
         with open(package_json_path, "r", encoding="utf-8") as f:
             package_json = json.load(f)
 
-        package_name = package_json["name"]
+        original_name = package_json["name"]
         version = package_json["version"]
-
-        logger.info(
-            f"Publishing {package_name}@{version} to {self.registry} registry"
+        scoped_name = self._compute_scoped_name(original_name)
+        browse_url = self._package_browse_url(
+            scoped_name, original_name, version
         )
 
-        # Create a temporary directory for npm operations
-        with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
+        logger.info(
+            f"Publishing {scoped_name}@{version} to "
+            f"{self.registry} registry"
+        )
 
-            # Copy package to temp directory
-            package_copy = temp_path / "package"
-            self._copy_package(package_dir, package_copy)
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_path = Path(temp_dir)
 
-            # Update package.json for the target registry
-            self._update_package_json(package_copy / "package.json")
+                package_copy = temp_path / "package"
+                self._copy_package(package_dir, package_copy)
+                self._update_package_json(package_copy / "package.json")
+                self._configure_npm(temp_path)
+                self._npm_publish(package_copy)
 
-            # Configure npm for the target registry
-            self._configure_npm(temp_path)
-
-            # Publish using npm
-            self._npm_publish(package_copy)
-
-        logger.info(f"Successfully published {package_name}@{version}")
+            logger.info(
+                f"Successfully published {scoped_name}@{version}. "
+                f"View at: {browse_url}"
+            )
+        except subprocess.CalledProcessError as e:
+            if self._is_publish_conflict(e):
+                logger.warning(
+                    f"{scoped_name}@{version} already published "
+                    f"(version conflict). View at: {browse_url}"
+                )
+            else:
+                logger.error(f"npm publish failed: {e.stderr}")
+                raise
 
     def _copy_package(self, source: Path, dest: Path) -> None:
         """Copy package directory to destination."""
@@ -146,20 +220,9 @@ class PackagePublisher:
         with open(package_json_path, "r", encoding="utf-8") as f:
             package_json = json.load(f)
 
-        # Update package name with scope if needed
         original_name = package_json["name"]
+        package_json["name"] = self._compute_scoped_name(original_name)
 
-        if self.registry == "github" and self.owner:
-            # GitHub requires scoped packages
-            if not original_name.startswith("@"):
-                package_json["name"] = f"@{self.owner}/{original_name}"
-        elif self.registry == "npmjs" and self.owner:
-            # npmjs can use scoped packages
-            if not original_name.startswith("@"):
-                package_json["name"] = f"@{self.owner}/{original_name}"
-        # OpenUPM doesn't require scoping
-
-        # Add repository information
         if self.owner and self.registry in ["github", "npmjs"]:
             package_json["repository"] = {
                 "type": "git",
@@ -169,11 +232,9 @@ class PackagePublisher:
                 ),
             }
 
-        # Add publishConfig for GitHub
         if self.registry == "github":
             package_json["publishConfig"] = {"registry": self.config["url"]}
 
-        # Write updated package.json
         with open(package_json_path, "w", encoding="utf-8") as f:
             json.dump(package_json, f, indent=2, ensure_ascii=False)
 
@@ -201,18 +262,14 @@ class PackagePublisher:
             )
             return
 
-        try:
-            result = subprocess.run(
-                ["npm", "publish"],
-                cwd=package_dir,
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            logger.debug(f"npm publish output: {result.stdout}")
-        except subprocess.CalledProcessError as e:
-            logger.error(f"npm publish failed: {e.stderr}")
-            raise
+        result = subprocess.run(
+            ["npm", "publish"],
+            cwd=package_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        logger.debug(f"npm publish output: {result.stdout}")
 
     def check_package_exists(self, package_name: str, version: str) -> bool:
         """Check if a package version already exists in the registry."""
@@ -220,10 +277,7 @@ class PackagePublisher:
             logger.info("OpenUPM package existence check not implemented")
             return False
 
-        scoped_name = package_name
-        if self.registry in ["github", "npmjs"] and self.owner:
-            if not package_name.startswith("@"):
-                scoped_name = f"@{self.owner}/{package_name}"
+        scoped_name = self._compute_scoped_name(package_name)
 
         try:
             subprocess.run(

--- a/tests/test_package_publisher.py
+++ b/tests/test_package_publisher.py
@@ -241,7 +241,14 @@ class TestPublishPackage:
             with caplog.at_level(logging.WARNING):
                 pub.publish_package(pkg_dir)  # must not raise
 
-        assert "version conflict" in caplog.text
+        assert any(
+            record.levelno == logging.WARNING
+            and "version conflict" in record.getMessage()
+            for record in caplog.records
+        ), "Expected a WARNING record mentioning 'version conflict'"
+        assert not any(
+            record.levelno >= logging.ERROR for record in caplog.records
+        ), "Expected no ERROR records for a version conflict"
         assert "View at:" in caplog.text
 
     def test_conflict_does_not_raise(self, tmp_path: Path) -> None:

--- a/tests/test_package_publisher.py
+++ b/tests/test_package_publisher.py
@@ -1,0 +1,287 @@
+"""Tests for PackagePublisher."""
+
+import json
+import logging
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from unity_wrapper.utils.package_publisher import PackagePublisher
+
+
+def _make_publisher(
+    registry: str = "github",
+    owner: str = "testowner",
+    token: str = "tok",
+) -> PackagePublisher:
+    """Helper to create a PackagePublisher with npm mocked out."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="10.0.0", returncode=0)
+        return PackagePublisher(registry=registry, token=token, owner=owner)
+
+
+class TestGetRepoFromEnv:
+    def test_returns_repo_part_from_github_repository(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="10.0.0", returncode=0)
+            with patch.dict(
+                os.environ,
+                {"GITHUB_REPOSITORY": "owner/my-repo", "GITHUB_TOKEN": "t"},
+                clear=True,
+            ):
+                pub = PackagePublisher(registry="github")
+                assert pub.repo == "my-repo"
+
+    def test_returns_none_when_env_not_set(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="10.0.0", returncode=0)
+            with patch.dict(os.environ, {}, clear=True):
+                pub = PackagePublisher(
+                    registry="openupm", token=None, owner=None
+                )
+                assert pub.repo is None
+
+    def test_handles_repo_name_with_dots(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="10.0.0", returncode=0)
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_REPOSITORY": "owner/pkg.package-wrappers-unity",
+                    "GITHUB_TOKEN": "t",
+                },
+                clear=True,
+            ):
+                pub = PackagePublisher(registry="github")
+                assert pub.repo == "pkg.package-wrappers-unity"
+
+
+class TestComputeScopedName:
+    def test_github_adds_owner_scope(self) -> None:
+        pub = _make_publisher(registry="github")
+        assert (
+            pub._compute_scoped_name("com.foo.bar") == "@testowner/com.foo.bar"
+        )
+
+    def test_npmjs_adds_owner_scope(self) -> None:
+        pub = _make_publisher(registry="npmjs")
+        assert (
+            pub._compute_scoped_name("com.foo.bar") == "@testowner/com.foo.bar"
+        )
+
+    def test_openupm_no_scope(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="10.0.0", returncode=0)
+            pub = PackagePublisher(
+                registry="openupm", token=None, owner="testowner"
+            )
+        assert pub._compute_scoped_name("com.foo.bar") == "com.foo.bar"
+
+    def test_already_scoped_name_unchanged(self) -> None:
+        pub = _make_publisher(registry="github")
+        assert (
+            pub._compute_scoped_name("@testowner/com.foo.bar")
+            == "@testowner/com.foo.bar"
+        )
+
+    def test_no_owner_returns_name_unchanged(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="10.0.0", returncode=0)
+            with patch.dict(os.environ, {}, clear=True):
+                pub = PackagePublisher(
+                    registry="openupm", token=None, owner=None
+                )
+        assert pub._compute_scoped_name("com.foo.bar") == "com.foo.bar"
+
+
+class TestPackageBrowseUrl:
+    def test_github_with_owner_and_repo(self) -> None:
+        pub = _make_publisher(registry="github")
+        pub.repo = "my-wrappers"
+        url = pub._package_browse_url(
+            "@testowner/com.foo.bar", "com.foo.bar", "1.0.0"
+        )
+        assert url == (
+            "https://github.com/testowner/my-wrappers/pkgs/npm/com.foo.bar"
+        )
+
+    def test_github_without_repo_falls_back_to_packages_tab(self) -> None:
+        pub = _make_publisher(registry="github")
+        pub.repo = None
+        url = pub._package_browse_url(
+            "@testowner/com.foo.bar", "com.foo.bar", "1.0.0"
+        )
+        assert url == "https://github.com/testowner?tab=packages"
+
+    def test_github_without_owner_returns_github_root(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="10.0.0", returncode=0)
+            with patch.dict(os.environ, {}, clear=True):
+                pub = PackagePublisher(
+                    registry="openupm", token=None, owner=None
+                )
+        pub.registry = "github"
+        pub.owner = None
+        pub.repo = None
+        url = pub._package_browse_url("com.foo.bar", "com.foo.bar", "1.0.0")
+        assert url == "https://github.com"
+
+    def test_npmjs_url_includes_version(self) -> None:
+        pub = _make_publisher(registry="npmjs")
+        url = pub._package_browse_url(
+            "@testowner/com.foo.bar", "com.foo.bar", "2.3.4"
+        )
+        assert url == (
+            "https://www.npmjs.com/package/@testowner/com.foo.bar/v/2.3.4"
+        )
+
+    def test_openupm_url_uses_original_name(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="10.0.0", returncode=0)
+            pub = PackagePublisher(
+                registry="openupm", token=None, owner="testowner"
+            )
+        url = pub._package_browse_url("com.foo.bar", "com.foo.bar", "1.0.0")
+        assert url == "https://openupm.com/packages/com.foo.bar/"
+
+
+class TestIsPublishConflict:
+    def _err(self, stderr: str) -> subprocess.CalledProcessError:
+        return subprocess.CalledProcessError(1, "npm", stderr=stderr)
+
+    def test_detects_e409(self) -> None:
+        pub = _make_publisher()
+        assert pub._is_publish_conflict(self._err("npm ERR! code E409"))
+
+    def test_detects_409_conflict(self) -> None:
+        pub = _make_publisher()
+        assert pub._is_publish_conflict(self._err("409 Conflict - PUT"))
+
+    def test_detects_already_exists(self) -> None:
+        pub = _make_publisher()
+        assert pub._is_publish_conflict(self._err("version already exists"))
+
+    def test_detects_cannot_publish_over(self) -> None:
+        pub = _make_publisher()
+        assert pub._is_publish_conflict(
+            self._err("cannot publish over the previously published versions")
+        )
+
+    def test_detects_epublishconflict(self) -> None:
+        pub = _make_publisher()
+        assert pub._is_publish_conflict(self._err("EPUBLISHCONFLICT"))
+
+    def test_non_conflict_error_returns_false(self) -> None:
+        pub = _make_publisher()
+        assert not pub._is_publish_conflict(
+            self._err("ENEEDAUTH need auth npm ERR!")
+        )
+
+    def test_none_stderr_does_not_raise(self) -> None:
+        pub = _make_publisher()
+        err = subprocess.CalledProcessError(1, "npm")
+        err.stderr = None
+        assert not pub._is_publish_conflict(err)
+
+
+class TestPublishPackage:
+    _PKG_JSON = json.dumps({"name": "com.foo.bar", "version": "1.2.3"})
+
+    def _publisher_with_repo(self) -> PackagePublisher:
+        pub = _make_publisher(registry="github")
+        pub.repo = "my-wrappers"
+        return pub
+
+    def test_success_logs_url(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        tmp_path: Path,
+    ) -> None:
+        pkg_dir = tmp_path / "pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "package.json").write_text(self._PKG_JSON)
+
+        pub = self._publisher_with_repo()
+
+        with (
+            patch.object(pub, "_copy_package"),
+            patch.object(pub, "_update_package_json"),
+            patch.object(pub, "_configure_npm"),
+            patch.object(pub, "_npm_publish"),
+        ):
+            with caplog.at_level(logging.INFO):
+                pub.publish_package(pkg_dir)
+
+        assert "View at:" in caplog.text
+        assert "/pkgs/npm/com.foo.bar" in caplog.text
+
+    def test_conflict_logs_warning_not_error(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        tmp_path: Path,
+    ) -> None:
+        pkg_dir = tmp_path / "pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "package.json").write_text(self._PKG_JSON)
+
+        pub = self._publisher_with_repo()
+        conflict = subprocess.CalledProcessError(
+            1, "npm", stderr="npm ERR! code E409"
+        )
+
+        with (
+            patch.object(pub, "_copy_package"),
+            patch.object(pub, "_update_package_json"),
+            patch.object(pub, "_configure_npm"),
+            patch.object(pub, "_npm_publish", side_effect=conflict),
+        ):
+            with caplog.at_level(logging.WARNING):
+                pub.publish_package(pkg_dir)  # must not raise
+
+        assert "version conflict" in caplog.text
+        assert "View at:" in caplog.text
+
+    def test_conflict_does_not_raise(self, tmp_path: Path) -> None:
+        pkg_dir = tmp_path / "pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "package.json").write_text(self._PKG_JSON)
+
+        pub = self._publisher_with_repo()
+        conflict = subprocess.CalledProcessError(
+            1, "npm", stderr="E409 conflict"
+        )
+
+        with (
+            patch.object(pub, "_copy_package"),
+            patch.object(pub, "_update_package_json"),
+            patch.object(pub, "_configure_npm"),
+            patch.object(pub, "_npm_publish", side_effect=conflict),
+        ):
+            pub.publish_package(pkg_dir)  # should not raise
+
+    def test_non_conflict_error_raises(self, tmp_path: Path) -> None:
+        pkg_dir = tmp_path / "pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "package.json").write_text(self._PKG_JSON)
+
+        pub = self._publisher_with_repo()
+        auth_err = subprocess.CalledProcessError(
+            1, "npm", stderr="ENEEDAUTH need auth"
+        )
+
+        with (
+            patch.object(pub, "_copy_package"),
+            patch.object(pub, "_update_package_json"),
+            patch.object(pub, "_configure_npm"),
+            patch.object(pub, "_npm_publish", side_effect=auth_err),
+        ):
+            with pytest.raises(subprocess.CalledProcessError):
+                pub.publish_package(pkg_dir)
+
+    def test_missing_package_json_raises(self, tmp_path: Path) -> None:
+        pub = self._publisher_with_repo()
+        with pytest.raises(FileNotFoundError, match="package.json not found"):
+            pub.publish_package(tmp_path / "nonexistent")


### PR DESCRIPTION
## Summary

Log a browser-accessible URL whenever a package is published (or skipped due to a version conflict), and demote HTTP 409 "version already exists" errors from fatal to a warning.

## Changes

### `src/unity_wrapper/utils/package_publisher.py`
- **`_get_repo_from_env()`** — extracts repo name from `GITHUB_REPOSITORY` env var
- **`_compute_scoped_name()`** — single source of truth for `@owner/name` scoping (removes duplication from `_update_package_json` and `check_package_exists`)
- **`_package_browse_url()`** — constructs a registry-appropriate browser URL:
  - GitHub: `https://github.com/{owner}/{repo}/pkgs/npm/{name}`
  - npmjs: `https://www.npmjs.com/package/{scoped}/v/{version}`
  - OpenUPM: `https://openupm.com/packages/{name}/`
- **`_is_publish_conflict()`** — detects 409/version-conflict in npm stderr (`E409`, `already exists`, `cannot publish over`, `EPUBLISHCONFLICT`)
- **`publish_package()`** — logs `View at: <url>` on success (`INFO`) and on version conflict (`WARNING`, no raise); all other errors still propagate

### `tests/test_package_publisher.py` (new)
25 tests covering all new helpers and the success / conflict / non-conflict / missing-json publish paths.
`package_publisher.py` coverage: **20% → 67%**