### PR TITLE
feat: UPM-compatible publishing for GitHub registry

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -46,6 +46,8 @@ jobs:
     permissions:
       contents: read
       packages: write  # Required for publishing to GitHub Package Registry
+      pages: write     # Required for deploying to GitHub Pages
+      id-token: write  # Required for OIDC GitHub Pages deployment
     if: needs.check-changes.outputs.packages-changed == 'true' || needs.check-changes.outputs.config-changed == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 
     steps:
@@ -155,6 +157,20 @@ jobs:
         run: |
           echo "Publishing packages to GitHub Package Registry..."
           make publish REGISTRY=github OWNER=${{ github.repository_owner }}
+
+      - name: Configure GitHub Pages
+        if: (steps.check-updates.outputs.updates-needed == 'true' || github.event.inputs.package_name != '') && github.ref == 'refs/heads/main'
+        uses: actions/configure-pages@v4
+
+      - name: Upload static registry to GitHub Pages
+        if: (steps.check-updates.outputs.updates-needed == 'true' || github.event.inputs.package_name != '') && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/registry/
+
+      - name: Deploy static registry to GitHub Pages
+        if: (steps.check-updates.outputs.updates-needed == 'true' || github.event.inputs.package_name != '') && github.ref == 'refs/heads/main'
+        uses: actions/deploy-pages@v4
 
   test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ celerybeat.pid
 
 # End of https://www.toptal.com/developers/gitignore/api/python
 .npmrc
+dist/registry/

--- a/docs/unity-github-registry-limitations.md
+++ b/docs/unity-github-registry-limitations.md
@@ -111,16 +111,21 @@ GitHub infers the scope from the `repository` field when the package name is not
 
 ## What the Unity Consumer Side Looks Like
 
-For reference, here is how a Unity project consumes these packages. You do not need to change this, but it helps to understand what the consumer expects.
+For reference, here is how a Unity project consumes these packages.
 
 ### `Packages/manifest.json`
+
+The registry `url` **must include the owner scope path** (`/@klumhru`), not just
+the bare `npm.pkg.github.com` domain. This is because GitHub Packages stores
+all packages under a scoped path and only responds to queries at that path;
+querying the bare domain for an unscoped package name returns 404.
 
 ```json
 {
   "scopedRegistries": [
     {
       "name": "GitHub - klumhru",
-      "url": "https://npm.pkg.github.com",
+      "url": "https://npm.pkg.github.com/@klumhru",
       "scopes": [
         "com.klumhru"
       ]
@@ -132,40 +137,54 @@ For reference, here is how a Unity project consumes these packages. You do not n
 }
 ```
 
+When UPM resolves `com.klumhru.wrapper.some-package`, it appends the package
+name to the registry `url`, producing:
+`https://npm.pkg.github.com/@klumhru/com.klumhru.wrapper.some-package` —
+which is the exact path where the package lives in GitHub Packages.
+
 ### `.upmconfig.toml` (in user home directory)
 
+The token auth entry **must match the registry `url` exactly** (including the
+`/@klumhru` path), otherwise authentication fails silently.
+
 ```toml
-[npmAuth."https://npm.pkg.github.com"]
+[npmAuth."https://npm.pkg.github.com/@klumhru"]
 token = "ghp_XXXXX"
 alwaysAuth = true
 ```
 
-**Critical detail:** The key in `npmAuth` must be an exact URL prefix match with the `url` in `manifest.json`. If these don't match, authentication fails silently and Unity reports invalid credentials.
-
 ---
 
-## Summary of Required Changes to the Publishing Pipeline
+## Summary of the Implemented Publishing Strategy
 
-1. **Remove the `@klumhru/` prefix from the `name` field** in every `package.json` that gets published. The name must be the bare UPM identifier (e.g. `com.klumhru.wrapper.some-package`).
+The pipeline uses **direct HTTP PUT** to GitHub Packages instead of the npm
+CLI, which allows full control over the request:
 
-2. **Add a `repository` field** to `package.json` pointing to the GitHub repository. GitHub uses this to determine ownership when the name is unscoped.
+1. **`npm pack`** creates the tarball. The `package.json` inside the tarball
+   keeps the **unscoped** UPM name (`com.klumhru.wrapper.some-package`), so
+   Unity can install and resolve it correctly after download.
 
-3. **Add a `publishConfig` block** to `package.json` with `"registry": "https://npm.pkg.github.com"`, or configure this via `.npmrc`.
+2. A **packument** document is constructed with:
+   - `name`: scoped name (`@klumhru/com.klumhru.wrapper.some-package`) — required by GitHub for routing
+   - `_attachments` key: `@klumhru/com.klumhru.wrapper.some-package-{version}.tgz` — GitHub requires the attachment key to be `{packument.name}-{version}.tgz`
 
-4. **Publish with the scope flag**: `npm publish --scope=@klumhru`, or rely on the `repository` field for GitHub to infer ownership.
+3. The packument is **PUT to** `https://npm.pkg.github.com/@klumhru/com.klumhru.wrapper.some-package`.
 
-5. **Ensure the authentication token** used for publishing has `write:packages` scope.
-
-6. **If packages are already published with the scoped name**, they may need to be deleted and republished with the unscoped name. GitHub does not support renaming published packages. Check if the old scoped versions need to be cleaned up.
+4. **Versions must use strict semver** (e.g. `31.1.0`, not `v31.1.0`). The
+   pipeline strips any leading `v` automatically.
 
 ---
 
 ## Verification
 
-After publishing, verify the package is correctly named by querying the registry:
+After publishing, verify the package is accessible:
 
 ```bash
-npm --registry https://npm.pkg.github.com view com.klumhru.wrapper.some-package
+# Requires a valid token with read:packages scope
+curl -H "Authorization: Bearer ghp_XXXXX" \
+  "https://npm.pkg.github.com/@klumhru/com.klumhru.wrapper.some-package"
 ```
 
-This should return the package metadata with the unscoped name. If it returns nothing or an error, the package was likely published with the scope in the name and needs to be republished.
+The response lists available versions. The `name` field in the response will
+be the scoped name; the tarball's internal `package.json` contains the unscoped
+UPM name.

--- a/docs/unity-github-registry-limitations.md
+++ b/docs/unity-github-registry-limitations.md
@@ -1,0 +1,171 @@
+# Publishing Unity Package Manager Packages to GitHub's npm Registry
+
+## Problem Summary
+
+Unity Package Manager (UPM) packages published to GitHub's npm package registry are not consumable by Unity clients. The root cause is a conflict between GitHub's requirement that all npm packages be scoped (e.g. `@klumhru/com.klumhru.some-package`) and Unity's inability to handle npm scopes. This document describes the constraints on both sides and what the publishing pipeline must do to produce compatible packages.
+
+---
+
+## The Two Conflicting Requirements
+
+### GitHub npm Registry Requires Scoped Packages
+
+GitHub's npm registry mandates that every package name begins with an npm scope matching the GitHub owner (user or organization). For a user named `klumhru`, every package must be named `@klumhru/something`. If you attempt to publish a package without the scope, the registry rejects it.
+
+This scope is set via the `name` field in `package.json`:
+
+```json
+{
+  "name": "@klumhru/com.klumhru.wrapper.some-package"
+}
+```
+
+GitHub uses this scope to determine which user/org owns the package.
+
+### Unity Package Manager Does Not Understand npm Scopes
+
+UPM resolves packages by their exact `name` field. When Unity sees a dependency like:
+
+```json
+"com.klumhru.wrapper.some-package": "1.0.0"
+```
+
+It queries the configured scoped registry for a package with that exact name. However, GitHub's registry returns the package metadata with the full scoped name `@klumhru/com.klumhru.wrapper.some-package`. UPM cannot match these two names, and resolution fails with an error like:
+
+```
+Expected to find progress reporting for @klumhru/com.klumhru.wrapper.some-package. No packages loaded.
+```
+
+UPM has no mechanism to map scoped npm names to unscoped UPM names. There is no configuration on the Unity side that can fix this.
+
+---
+
+## The Fix: Publish Without the Scope in `package.json`
+
+The solution is to publish packages where the `name` field in `package.json` does **not** include the `@owner/` scope prefix. Instead, the scope is provided at publish time via npm configuration.
+
+### What `package.json` Must Look Like
+
+The `name` field must be the bare UPM package name with no npm scope:
+
+```json
+{
+  "name": "com.klumhru.wrapper.some-package",
+  "version": "1.0.0",
+  "displayName": "Some Package Wrapper",
+  "unity": "6000.0"
+}
+```
+
+**Do not put `@klumhru/` in the name field.**
+
+### How to Tell GitHub Which Owner the Package Belongs To
+
+GitHub determines package ownership from the npm scope provided during publishing. This is configured in an `.npmrc` file (either in the project root or the user's home directory):
+
+```
+@klumhru:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=TOKEN
+```
+
+The first line tells npm: "any package published under the `@klumhru` scope should go to GitHub's registry." The second line provides the authentication token.
+
+### The Publish Command
+
+Use the `--scope` flag to attach the scope at publish time without it being in `package.json`:
+
+```bash
+npm publish --scope=@klumhru
+```
+
+This tells npm to treat the package as belonging to the `@klumhru` scope for registry routing purposes, but the package name stored in the registry metadata will be whatever is in `package.json` — the unscoped UPM name.
+
+### Alternative: Use `publishConfig` in `package.json`
+
+Instead of relying on `.npmrc` and the `--scope` flag, you can add a `publishConfig` block to `package.json`:
+
+```json
+{
+  "name": "com.klumhru.wrapper.some-package",
+  "version": "1.0.0",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
+}
+```
+
+Combined with a repository field that tells GitHub the owner:
+
+```json
+{
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/klumhru/your-repo.git"
+  }
+}
+```
+
+GitHub infers the scope from the `repository` field when the package name is not explicitly scoped. This approach may be cleaner for CI/CD pipelines.
+
+---
+
+## What the Unity Consumer Side Looks Like
+
+For reference, here is how a Unity project consumes these packages. You do not need to change this, but it helps to understand what the consumer expects.
+
+### `Packages/manifest.json`
+
+```json
+{
+  "scopedRegistries": [
+    {
+      "name": "GitHub - klumhru",
+      "url": "https://npm.pkg.github.com",
+      "scopes": [
+        "com.klumhru"
+      ]
+    }
+  ],
+  "dependencies": {
+    "com.klumhru.wrapper.some-package": "1.0.0"
+  }
+}
+```
+
+### `.upmconfig.toml` (in user home directory)
+
+```toml
+[npmAuth."https://npm.pkg.github.com"]
+token = "ghp_XXXXX"
+alwaysAuth = true
+```
+
+**Critical detail:** The key in `npmAuth` must be an exact URL prefix match with the `url` in `manifest.json`. If these don't match, authentication fails silently and Unity reports invalid credentials.
+
+---
+
+## Summary of Required Changes to the Publishing Pipeline
+
+1. **Remove the `@klumhru/` prefix from the `name` field** in every `package.json` that gets published. The name must be the bare UPM identifier (e.g. `com.klumhru.wrapper.some-package`).
+
+2. **Add a `repository` field** to `package.json` pointing to the GitHub repository. GitHub uses this to determine ownership when the name is unscoped.
+
+3. **Add a `publishConfig` block** to `package.json` with `"registry": "https://npm.pkg.github.com"`, or configure this via `.npmrc`.
+
+4. **Publish with the scope flag**: `npm publish --scope=@klumhru`, or rely on the `repository` field for GitHub to infer ownership.
+
+5. **Ensure the authentication token** used for publishing has `write:packages` scope.
+
+6. **If packages are already published with the scoped name**, they may need to be deleted and republished with the unscoped name. GitHub does not support renaming published packages. Check if the old scoped versions need to be cleaned up.
+
+---
+
+## Verification
+
+After publishing, verify the package is correctly named by querying the registry:
+
+```bash
+npm --registry https://npm.pkg.github.com view com.klumhru.wrapper.some-package
+```
+
+This should return the package metadata with the unscoped name. If it returns nothing or an error, the package was likely published with the scope in the name and needs to be republished.

--- a/docs/unity-github-registry-limitations.md
+++ b/docs/unity-github-registry-limitations.md
@@ -111,21 +111,30 @@ GitHub infers the scope from the `repository` field when the package name is not
 
 ## What the Unity Consumer Side Looks Like
 
-For reference, here is how a Unity project consumes these packages.
+GitHub Packages always returns scoped names in packument responses (e.g.
+`@klumhru/com.foo.bar`).  UPM validates the `name` field in the packument
+and fails with:
+
+```
+Expected to find progress reporting for @klumhru/com.foo.bar. No packages loaded.
+```
+
+To work around this, the pipeline additionally generates a **static npm
+registry** deployed to GitHub Pages.  The Pages registry serves packuments
+with the correct unscoped names; tarballs are still downloaded from GitHub
+Packages.
 
 ### `Packages/manifest.json`
 
-The registry `url` **must include the owner scope path** (`/@klumhru`), not just
-the bare `npm.pkg.github.com` domain. This is because GitHub Packages stores
-all packages under a scoped path and only responds to queries at that path;
-querying the bare domain for an unscoped package name returns 404.
+Point the scoped registry at the GitHub Pages URL, **not** at
+`npm.pkg.github.com`:
 
 ```json
 {
   "scopedRegistries": [
     {
-      "name": "GitHub - klumhru",
-      "url": "https://npm.pkg.github.com/@klumhru",
+      "name": "klumhru packages",
+      "url": "https://klumhru.github.io/package-wrappers-unity",
       "scopes": [
         "com.klumhru"
       ]
@@ -137,54 +146,61 @@ querying the bare domain for an unscoped package name returns 404.
 }
 ```
 
-When UPM resolves `com.klumhru.wrapper.some-package`, it appends the package
-name to the registry `url`, producing:
-`https://npm.pkg.github.com/@klumhru/com.klumhru.wrapper.some-package` —
-which is the exact path where the package lives in GitHub Packages.
+The GitHub Pages URL is `https://{owner}.github.io/{repo}`.  UPM appends
+the package name to produce
+`https://klumhru.github.io/package-wrappers-unity/com.klumhru.wrapper.some-package`,
+which serves a static JSON packument with the unscoped name.
 
 ### `.upmconfig.toml` (in user home directory)
 
-The token auth entry **must match the registry `url` exactly** (including the
-`/@klumhru` path), otherwise authentication fails silently.
+Auth is needed for the **tarball download** (which comes from GitHub Packages).
+The key must match the base GitHub Packages domain so it covers all tarball
+URLs:
 
 ```toml
-[npmAuth."https://npm.pkg.github.com/@klumhru"]
+[npmAuth."https://npm.pkg.github.com"]
 token = "ghp_XXXXX"
 alwaysAuth = true
 ```
+
+No auth entry is needed for the GitHub Pages URL — it is a public static site.
 
 ---
 
 ## Summary of the Implemented Publishing Strategy
 
-The pipeline uses **direct HTTP PUT** to GitHub Packages instead of the npm
-CLI, which allows full control over the request:
+1. **`npm pack`** creates the tarball.  The `package.json` inside the tarball
+   keeps the **unscoped** UPM name (`com.klumhru.wrapper.some-package`).
 
-1. **`npm pack`** creates the tarball. The `package.json` inside the tarball
-   keeps the **unscoped** UPM name (`com.klumhru.wrapper.some-package`), so
-   Unity can install and resolve it correctly after download.
+2. A **packument** (scoped name in body, scoped PUT URL) is sent directly to
+   GitHub Packages via HTTP PUT.  This is required for GitHub routing — the
+   npm CLI cannot be used because it always derives the PUT URL from the
+   unscoped `name` field, which GitHub rejects with 404.
 
-2. A **packument** document is constructed with:
-   - `name`: scoped name (`@klumhru/com.klumhru.wrapper.some-package`) — required by GitHub for routing
-   - `_attachments` key: `@klumhru/com.klumhru.wrapper.some-package-{version}.tgz` — GitHub requires the attachment key to be `{packument.name}-{version}.tgz`
+3. After a successful publish, a **static packument JSON** is written to
+   `dist/registry/{package_name}.json` with:
+   - `name`: **unscoped** (e.g. `com.klumhru.wrapper.some-package`)
+   - `dist.tarball`: pointing to the GitHub Packages tarball URL
 
-3. The packument is **PUT to** `https://npm.pkg.github.com/@klumhru/com.klumhru.wrapper.some-package`.
+4. The CI workflow deploys `dist/registry/` to **GitHub Pages** via
+   `actions/deploy-pages`.
 
-4. **Versions must use strict semver** (e.g. `31.1.0`, not `v31.1.0`). The
-   pipeline strips any leading `v` automatically.
+5. **Versions must use strict semver** (e.g. `31.1.0`, not `v31.1.0`).  The
+   pipeline strips any leading `v` from git tag–style versions automatically.
+
+> **Enable GitHub Pages** in repository Settings → Pages → Source: GitHub
+> Actions, before the first deployment.
 
 ---
 
 ## Verification
 
-After publishing, verify the package is accessible:
-
 ```bash
-# Requires a valid token with read:packages scope
-curl -H "Authorization: Bearer ghp_XXXXX" \
-  "https://npm.pkg.github.com/@klumhru/com.klumhru.wrapper.some-package"
-```
+# 1. Check that the static packument (unscoped name) is served by GitHub Pages
+curl "https://klumhru.github.io/package-wrappers-unity/com.klumhru.wrapper.some-package"
 
-The response lists available versions. The `name` field in the response will
-be the scoped name; the tarball's internal `package.json` contains the unscoped
-UPM name.
+# 2. Check that the tarball is accessible (requires GitHub token)
+curl -H "Authorization: Bearer ghp_XXXXX" \
+  "https://npm.pkg.github.com/@klumhru/com.klumhru.wrapper.some-package/-/@klumhru/com.klumhru.wrapper.some-package-1.0.0.tgz" \
+  --head
+```

--- a/src/unity_wrapper/core/unity_generator.py
+++ b/src/unity_wrapper/core/unity_generator.py
@@ -46,10 +46,13 @@ class UnityGenerator:
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Generate Unity package.json content."""
+        # UPM requires strict semver without a leading 'v' (e.g. '1.0.0',
+        # not 'v1.0.0'). Strip any leading 'v' from git tag–style versions.
+        normalized_version = version.lstrip("v")
         package_json: Dict[str, Any] = {
             "name": name,
             "displayName": display_name,
-            "version": version,
+            "version": normalized_version,
             "description": description,
             "author": self._parse_author(author),
             "unity": "2019.4",

--- a/src/unity_wrapper/utils/package_publisher.py
+++ b/src/unity_wrapper/utils/package_publisher.py
@@ -175,13 +175,20 @@ class PackagePublisher:
 
         original_name = package_json["name"]
         version = package_json["version"]
-        scoped_name = self._compute_scoped_name(original_name)
+        # For GitHub, publish under the unscoped UPM name so Unity
+        # Package Manager can resolve it.  Scope is inferred by GitHub
+        # from the repository field and publishConfig.registry.
+        display_name = (
+            original_name
+            if self.registry == "github"
+            else self._compute_scoped_name(original_name)
+        )
         browse_url = self._package_browse_url(
-            scoped_name, original_name, version
+            display_name, original_name, version
         )
 
         logger.info(
-            f"Publishing {scoped_name}@{version} to "
+            f"Publishing {display_name}@{version} to "
             f"{self.registry} registry"
         )
 
@@ -196,13 +203,13 @@ class PackagePublisher:
                 self._npm_publish(package_copy)
 
             logger.info(
-                f"Successfully published {scoped_name}@{version}. "
+                f"Successfully published {display_name}@{version}. "
                 f"View at: {browse_url}"
             )
         except subprocess.CalledProcessError as e:
             if self._is_publish_conflict(e):
                 logger.warning(
-                    f"{scoped_name}@{version} already published "
+                    f"{display_name}@{version} already published "
                     f"(version conflict). View at: {browse_url}"
                 )
             else:
@@ -216,12 +223,22 @@ class PackagePublisher:
         shutil.copytree(source, dest)
 
     def _update_package_json(self, package_json_path: Path) -> None:
-        """Update package.json for the target registry."""
+        """Update package.json for the target registry.
+
+        For GitHub, the ``name`` field is kept unscoped (e.g.
+        ``com.foo.bar``) so that Unity Package Manager can resolve it.
+        GitHub infers ownership from the ``repository`` field and
+        ``publishConfig.registry``. For npmjs the name is scoped
+        (e.g. ``@owner/com.foo.bar``).
+        """
         with open(package_json_path, "r", encoding="utf-8") as f:
             package_json = json.load(f)
 
         original_name = package_json["name"]
-        package_json["name"] = self._compute_scoped_name(original_name)
+        # GitHub: keep unscoped name for UPM compatibility.
+        # npmjs: scope the name so consumers can install it.
+        if self.registry != "github":
+            package_json["name"] = self._compute_scoped_name(original_name)
 
         if self.owner and self.registry in ["github", "npmjs"]:
             package_json["repository"] = {
@@ -277,7 +294,12 @@ class PackagePublisher:
             logger.info("OpenUPM package existence check not implemented")
             return False
 
-        scoped_name = self._compute_scoped_name(package_name)
+        # GitHub stores packages under their unscoped UPM name.
+        scoped_name = (
+            package_name
+            if self.registry == "github"
+            else self._compute_scoped_name(package_name)
+        )
 
         try:
             subprocess.run(

--- a/src/unity_wrapper/utils/package_publisher.py
+++ b/src/unity_wrapper/utils/package_publisher.py
@@ -271,7 +271,13 @@ class PackagePublisher:
             # OpenUPM submission is manual, not via npm publish
 
     def _npm_publish(self, package_dir: Path) -> None:
-        """Publish package using npm."""
+        """Publish package using npm.
+
+        For GitHub, ``--scope=@{owner}`` is passed so the registry can
+        route the package to the correct owner without requiring the
+        scope to be embedded in the ``name`` field of ``package.json``.
+        This keeps the UPM-compatible unscoped name intact.
+        """
         if self.registry == "openupm":
             logger.warning(
                 "OpenUPM packages must be submitted manually at "
@@ -279,8 +285,12 @@ class PackagePublisher:
             )
             return
 
+        cmd = ["npm", "publish"]
+        if self.registry == "github" and self.owner:
+            cmd += [f"--scope=@{self.owner}"]
+
         result = subprocess.run(
-            ["npm", "publish"],
+            cmd,
             cwd=package_dir,
             check=True,
             capture_output=True,

--- a/src/unity_wrapper/utils/package_publisher.py
+++ b/src/unity_wrapper/utils/package_publisher.py
@@ -13,6 +13,8 @@ from typing import Any, Dict, Optional
 
 import requests as http_requests
 
+from unity_wrapper.utils.pages_publisher import PagesPublisher
+
 logger = logging.getLogger(__name__)
 
 
@@ -171,8 +173,22 @@ class PackagePublisher:
                 "npm is not available. Please install Node.js and npm."
             ) from e
 
-    def publish_package(self, package_dir: Path) -> None:
-        """Publish a Unity package to the configured registry."""
+    def publish_package(
+        self,
+        package_dir: Path,
+        registry_dir: Optional[Path] = None,
+    ) -> None:
+        """Publish a Unity package to the configured registry.
+
+        Args:
+            package_dir: Path to the built Unity package directory.
+            registry_dir: Optional directory for static packument files
+                used by the GitHub Pages registry.  Only used when
+                ``registry == 'github'``.  Defaults to
+                ``dist/registry`` relative to the current working
+                directory when ``registry == 'github'`` and this
+                argument is ``None``.
+        """
         package_json_path = package_dir / "package.json"
 
         if not package_json_path.exists():
@@ -193,6 +209,9 @@ class PackagePublisher:
             f"{self.registry} registry"
         )
 
+        if self.registry == "github" and registry_dir is None:
+            registry_dir = Path("dist/registry")
+
         try:
             with tempfile.TemporaryDirectory() as temp_dir:
                 temp_path = Path(temp_dir)
@@ -200,7 +219,9 @@ class PackagePublisher:
                 self._copy_package(package_dir, package_copy)
                 self._update_package_json(package_copy / "package.json")
                 if self.registry == "github":
-                    self._github_publish_direct(package_copy)
+                    self._github_publish_direct(
+                        package_copy, registry_dir=registry_dir
+                    )
                 else:
                     self._configure_npm(temp_path)
                     self._npm_publish(package_copy)
@@ -275,13 +296,21 @@ class PackagePublisher:
                     f.write(f"//registry.npmjs.org/:_authToken={self.token}\n")
             # OpenUPM submission is manual, not via npm publish
 
-    def _github_publish_direct(self, package_dir: Path) -> None:
+    def _github_publish_direct(
+        self,
+        package_dir: Path,
+        registry_dir: Optional[Path] = None,
+    ) -> None:
         """Publish to GitHub Packages using the npm registry HTTP API.
 
         Bypasses the npm CLI so we can PUT directly to the scoped URL
         (``/@owner/com.foo.bar``) that GitHub requires for routing, while
         keeping the ``name`` field inside the tarball unscoped
         (``com.foo.bar``) so Unity Package Manager can resolve it.
+
+        After a successful publish, writes a static packument JSON file
+        to ``registry_dir`` (if provided) with the unscoped name so that
+        a GitHub Pages-hosted registry can serve it to UPM consumers.
 
         Raises:
             _PublishConflict: If the version already exists (HTTP 409).
@@ -319,6 +348,7 @@ class PackagePublisher:
         # version: ``@owner/name-version.tgz``.  GitHub's npm registry
         # derives the attachment by matching this exact key format.
         attachment_key = f"{scoped_name}-{version}.tgz"
+        tarball_url = f"{self.config['url']}/{scoped_name}/-/{attachment_key}"
 
         version_meta: Dict[str, Any] = {
             **pkg_data,
@@ -327,10 +357,7 @@ class PackagePublisher:
             "dist": {
                 "integrity": integrity,
                 "shasum": shasum,
-                "tarball": (
-                    f"{self.config['url']}/{scoped_name}/-/"
-                    f"{attachment_key}"
-                ),
+                "tarball": tarball_url,
             },
         }
 
@@ -359,10 +386,36 @@ class PackagePublisher:
         )
 
         if response.status_code == 409:
+            # Version already exists — still update the static registry so
+            # the Pages packument stays current (e.g. on first run after
+            # adding PagesPublisher, or after a manual re-publish).
+            if registry_dir is not None:
+                PagesPublisher().update_registry(
+                    registry_dir=registry_dir,
+                    unscoped_name=original_name,
+                    version=version,
+                    version_meta=version_meta,
+                    tarball_url=tarball_url,
+                    shasum=shasum,
+                    integrity=integrity,
+                    description=pkg_data.get("description"),
+                )
             raise _PublishConflict(scoped_name)
 
         response.raise_for_status()
         logger.debug(f"GitHub publish HTTP status: {response.status_code}")
+
+        if registry_dir is not None:
+            PagesPublisher().update_registry(
+                registry_dir=registry_dir,
+                unscoped_name=original_name,
+                version=version,
+                version_meta=version_meta,
+                tarball_url=tarball_url,
+                shasum=shasum,
+                integrity=integrity,
+                description=pkg_data.get("description"),
+            )
 
     def _npm_publish(self, package_dir: Path) -> None:
         """Publish package using npm (non-GitHub registries)."""

--- a/src/unity_wrapper/utils/package_publisher.py
+++ b/src/unity_wrapper/utils/package_publisher.py
@@ -315,6 +315,11 @@ class PackagePublisher:
 
         # Registry metadata uses the scoped name for GitHub routing.
         # The tarball attachment contains the files with unscoped name.
+        # The attachment key must be the scoped name followed by the
+        # version: ``@owner/name-version.tgz``.  GitHub's npm registry
+        # derives the attachment by matching this exact key format.
+        attachment_key = f"{scoped_name}-{version}.tgz"
+
         version_meta: Dict[str, Any] = {
             **pkg_data,
             "name": scoped_name,
@@ -324,7 +329,7 @@ class PackagePublisher:
                 "shasum": shasum,
                 "tarball": (
                     f"{self.config['url']}/{scoped_name}/-/"
-                    f"{original_name}-{version}.tgz"
+                    f"{attachment_key}"
                 ),
             },
         }
@@ -335,7 +340,7 @@ class PackagePublisher:
             "dist-tags": {"latest": version},
             "versions": {version: version_meta},
             "_attachments": {
-                f"{original_name}-{version}.tgz": {
+                attachment_key: {
                     "content_type": "application/octet-stream",
                     "data": base64.b64encode(tarball_data).decode(),
                     "length": len(tarball_data),

--- a/src/unity_wrapper/utils/package_publisher.py
+++ b/src/unity_wrapper/utils/package_publisher.py
@@ -1,5 +1,7 @@
 """Package publisher for multiple registries."""
 
+import base64
+import hashlib
 import json
 import logging
 import os
@@ -9,7 +11,13 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+import requests as http_requests
+
 logger = logging.getLogger(__name__)
+
+
+class _PublishConflict(Exception):
+    """Raised when a package version already exists in the registry."""
 
 
 class PackagePublisher:
@@ -175,14 +183,7 @@ class PackagePublisher:
 
         original_name = package_json["name"]
         version = package_json["version"]
-        # For GitHub, publish under the unscoped UPM name so Unity
-        # Package Manager can resolve it.  Scope is inferred by GitHub
-        # from the repository field and publishConfig.registry.
-        display_name = (
-            original_name
-            if self.registry == "github"
-            else self._compute_scoped_name(original_name)
-        )
+        display_name = self._compute_scoped_name(original_name)
         browse_url = self._package_browse_url(
             display_name, original_name, version
         )
@@ -195,16 +196,23 @@ class PackagePublisher:
         try:
             with tempfile.TemporaryDirectory() as temp_dir:
                 temp_path = Path(temp_dir)
-
                 package_copy = temp_path / "package"
                 self._copy_package(package_dir, package_copy)
                 self._update_package_json(package_copy / "package.json")
-                self._configure_npm(temp_path)
-                self._npm_publish(package_copy)
+                if self.registry == "github":
+                    self._github_publish_direct(package_copy)
+                else:
+                    self._configure_npm(temp_path)
+                    self._npm_publish(package_copy)
 
             logger.info(
                 f"Successfully published {display_name}@{version}. "
                 f"View at: {browse_url}"
+            )
+        except _PublishConflict:
+            logger.warning(
+                f"{display_name}@{version} already published "
+                f"(version conflict). View at: {browse_url}"
             )
         except subprocess.CalledProcessError as e:
             if self._is_publish_conflict(e):
@@ -227,15 +235,15 @@ class PackagePublisher:
 
         For GitHub, the ``name`` field is kept unscoped (e.g.
         ``com.foo.bar``) so that Unity Package Manager can resolve it.
-        GitHub infers ownership from the ``repository`` field and
-        ``publishConfig.registry``. For npmjs the name is scoped
+        The scope is applied at publish time via the direct HTTP PUT
+        URL, not via the ``name`` field.  For npmjs the name is scoped
         (e.g. ``@owner/com.foo.bar``).
         """
         with open(package_json_path, "r", encoding="utf-8") as f:
             package_json = json.load(f)
 
         original_name = package_json["name"]
-        # GitHub: keep unscoped name for UPM compatibility.
+        # GitHub: keep unscoped name in the tarball for UPM compatibility.
         # npmjs: scope the name so consumers can install it.
         if self.registry != "github":
             package_json["name"] = self._compute_scoped_name(original_name)
@@ -248,9 +256,6 @@ class PackagePublisher:
                     f"{original_name}.package-wrappers-unity.git"
                 ),
             }
-
-        if self.registry == "github":
-            package_json["publishConfig"] = {"registry": self.config["url"]}
 
         with open(package_json_path, "w", encoding="utf-8") as f:
             json.dump(package_json, f, indent=2, ensure_ascii=False)
@@ -270,14 +275,92 @@ class PackagePublisher:
                     f.write(f"//registry.npmjs.org/:_authToken={self.token}\n")
             # OpenUPM submission is manual, not via npm publish
 
-    def _npm_publish(self, package_dir: Path) -> None:
-        """Publish package using npm.
+    def _github_publish_direct(self, package_dir: Path) -> None:
+        """Publish to GitHub Packages using the npm registry HTTP API.
 
-        For GitHub, ``--scope=@{owner}`` is passed so the registry can
-        route the package to the correct owner without requiring the
-        scope to be embedded in the ``name`` field of ``package.json``.
-        This keeps the UPM-compatible unscoped name intact.
+        Bypasses the npm CLI so we can PUT directly to the scoped URL
+        (``/@owner/com.foo.bar``) that GitHub requires for routing, while
+        keeping the ``name`` field inside the tarball unscoped
+        (``com.foo.bar``) so Unity Package Manager can resolve it.
+
+        Raises:
+            _PublishConflict: If the version already exists (HTTP 409).
+            requests.HTTPError: For other HTTP errors.
         """
+        with open(package_dir / "package.json", encoding="utf-8") as f:
+            pkg_data: Dict[str, Any] = json.load(f)
+
+        original_name = pkg_data["name"]  # unscoped: com.foo.bar
+        version = pkg_data["version"]
+        scoped_name = self._compute_scoped_name(original_name)
+
+        # Create tarball with npm pack.  The package.json inside the
+        # tarball keeps the unscoped name for UPM.
+        with tempfile.TemporaryDirectory() as tmp:
+            result = subprocess.run(
+                ["npm", "pack", "--pack-destination", tmp],
+                cwd=package_dir,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            tarball_filename = result.stdout.strip().split("\n")[-1]
+            tarball_data = (Path(tmp) / tarball_filename).read_bytes()
+
+        shasum = hashlib.sha1(tarball_data).hexdigest()  # nosec B324
+        integrity = (
+            "sha512-"
+            + base64.b64encode(hashlib.sha512(tarball_data).digest()).decode()
+        )
+
+        # Registry metadata uses the scoped name for GitHub routing.
+        # The tarball attachment contains the files with unscoped name.
+        version_meta: Dict[str, Any] = {
+            **pkg_data,
+            "name": scoped_name,
+            "_id": f"{scoped_name}@{version}",
+            "dist": {
+                "integrity": integrity,
+                "shasum": shasum,
+                "tarball": (
+                    f"{self.config['url']}/{scoped_name}/-/"
+                    f"{original_name}-{version}.tgz"
+                ),
+            },
+        }
+
+        packument = {
+            "_id": scoped_name,
+            "name": scoped_name,
+            "dist-tags": {"latest": version},
+            "versions": {version: version_meta},
+            "_attachments": {
+                f"{original_name}-{version}.tgz": {
+                    "content_type": "application/octet-stream",
+                    "data": base64.b64encode(tarball_data).decode(),
+                    "length": len(tarball_data),
+                }
+            },
+        }
+
+        url = f"{self.config['url']}/{scoped_name}"
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+            "Accept": "application/vnd.npm.install-v1+json",
+        }
+        response = http_requests.put(
+            url, json=packument, headers=headers, timeout=120
+        )
+
+        if response.status_code == 409:
+            raise _PublishConflict(scoped_name)
+
+        response.raise_for_status()
+        logger.debug(f"GitHub publish HTTP status: {response.status_code}")
+
+    def _npm_publish(self, package_dir: Path) -> None:
+        """Publish package using npm (non-GitHub registries)."""
         if self.registry == "openupm":
             logger.warning(
                 "OpenUPM packages must be submitted manually at "
@@ -285,12 +368,8 @@ class PackagePublisher:
             )
             return
 
-        cmd = ["npm", "publish"]
-        if self.registry == "github" and self.owner:
-            cmd += [f"--scope=@{self.owner}"]
-
         result = subprocess.run(
-            cmd,
+            ["npm", "publish"],
             cwd=package_dir,
             check=True,
             capture_output=True,
@@ -304,12 +383,7 @@ class PackagePublisher:
             logger.info("OpenUPM package existence check not implemented")
             return False
 
-        # GitHub stores packages under their unscoped UPM name.
-        scoped_name = (
-            package_name
-            if self.registry == "github"
-            else self._compute_scoped_name(package_name)
-        )
+        scoped_name = self._compute_scoped_name(package_name)
 
         try:
             subprocess.run(

--- a/src/unity_wrapper/utils/pages_publisher.py
+++ b/src/unity_wrapper/utils/pages_publisher.py
@@ -1,0 +1,136 @@
+"""Static npm registry generator for GitHub Pages.
+
+Generates unscoped packument JSON files that can be served by any
+static file host (e.g. GitHub Pages) as a UPM-compatible npm registry.
+
+The problem this solves
+-----------------------
+GitHub Packages always returns a *scoped* package name in its packument
+responses (e.g. ``@klumhru/com.foo.bar``).  Unity Package Manager
+(UPM) requires *unscoped* names (e.g. ``com.foo.bar``) and fails to
+resolve packages whose packument ``name`` field contains a ``@scope/``
+prefix.
+
+By generating static packument files with the correct unscoped name
+and hosting them on GitHub Pages, UPM can resolve packages normally.
+The tarball download URLs still point to GitHub Packages, so the
+existing ``.upmconfig.toml`` token is reused for auth.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class PagesPublisher:
+    """Generates static npm packument files for a GitHub Pages registry.
+
+    Each package gets a single JSON file at
+    ``{registry_dir}/{package_name}.json`` following the npm packument
+    format.  Multiple versions accumulate in the same file; the
+    ``dist-tags.latest`` tag always points to the most-recently-added
+    version.
+
+    Example usage::
+
+        pub = PagesPublisher()
+        pub.update_registry(
+            registry_dir=Path("dist/registry"),
+            unscoped_name="com.foo.bar",
+            version="1.2.3",
+            version_meta={...},           # npm version object
+            tarball_url="https://...",
+            shasum="abc123",
+            integrity="sha512-...",
+        )
+    """
+
+    def update_registry(
+        self,
+        registry_dir: Path,
+        unscoped_name: str,
+        version: str,
+        version_meta: Dict[str, Any],
+        tarball_url: str,
+        shasum: str,
+        integrity: str,
+        description: Optional[str] = None,
+    ) -> Path:
+        """Create or update the static packument file for a package.
+
+        If the file already exists, the new version is merged into the
+        existing packument and ``dist-tags.latest`` is updated.
+
+        Args:
+            registry_dir: Directory where packument JSON files are stored.
+            unscoped_name: Unscoped UPM package name (e.g.
+                ``com.foo.bar``).
+            version: Semver version string (e.g. ``1.2.3``).
+            version_meta: npm version metadata dict to embed under the
+                version key.  The ``name`` field will be overwritten with
+                ``unscoped_name``; ``dist`` will be set from the
+                ``tarball_url``, ``shasum``, and ``integrity`` args.
+            tarball_url: Publicly accessible (or auth-gated) tarball URL.
+            shasum: SHA-1 hex digest of the tarball.
+            integrity: SRI integrity string (e.g. ``sha512-...``).
+            description: Optional human-readable description; used only
+                when creating a new packument file.
+
+        Returns:
+            Path to the written packument JSON file.
+        """
+        registry_dir.mkdir(parents=True, exist_ok=True)
+        packument_path = registry_dir / f"{unscoped_name}.json"
+
+        packument = self._load_or_create(
+            packument_path, unscoped_name, description
+        )
+
+        version_entry: Dict[str, Any] = dict(version_meta)
+        version_entry["name"] = unscoped_name
+        version_entry["version"] = version
+        version_entry["dist"] = {
+            "tarball": tarball_url,
+            "shasum": shasum,
+            "integrity": integrity,
+        }
+        # Ensure the version entry name is never scoped.
+        version_entry.pop("_id", None)
+
+        packument["versions"][version] = version_entry
+        packument["dist-tags"]["latest"] = version
+
+        with open(packument_path, "w", encoding="utf-8") as f:
+            json.dump(packument, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+
+        logger.info(
+            f"Updated static registry: {packument_path} "
+            f"({unscoped_name}@{version})"
+        )
+        return packument_path
+
+    def _load_or_create(
+        self,
+        packument_path: Path,
+        unscoped_name: str,
+        description: Optional[str],
+    ) -> Dict[str, Any]:
+        """Load an existing packument or create a new skeleton."""
+        if packument_path.exists():
+            with open(packument_path, encoding="utf-8") as f:
+                existing: Dict[str, Any] = json.load(f)
+            # Ensure the name is always unscoped, even if an older run
+            # wrote a scoped name by mistake.
+            existing["name"] = unscoped_name
+            return existing
+
+        return {
+            "name": unscoped_name,
+            "description": description or "",
+            "dist-tags": {},
+            "versions": {},
+        }

--- a/tests/test_package_publisher.py
+++ b/tests/test_package_publisher.py
@@ -210,8 +210,7 @@ class TestPublishPackage:
         with (
             patch.object(pub, "_copy_package"),
             patch.object(pub, "_update_package_json"),
-            patch.object(pub, "_configure_npm"),
-            patch.object(pub, "_npm_publish"),
+            patch.object(pub, "_github_publish_direct"),
         ):
             with caplog.at_level(logging.INFO):
                 pub.publish_package(pkg_dir)
@@ -229,15 +228,18 @@ class TestPublishPackage:
         (pkg_dir / "package.json").write_text(self._PKG_JSON)
 
         pub = self._publisher_with_repo()
-        conflict = subprocess.CalledProcessError(
-            1, "npm", stderr="npm ERR! code E409"
-        )
+
+        # GitHub path raises _PublishConflict from _github_publish_direct
+        from unity_wrapper.utils.package_publisher import _PublishConflict
 
         with (
             patch.object(pub, "_copy_package"),
             patch.object(pub, "_update_package_json"),
-            patch.object(pub, "_configure_npm"),
-            patch.object(pub, "_npm_publish", side_effect=conflict),
+            patch.object(
+                pub,
+                "_github_publish_direct",
+                side_effect=_PublishConflict("pkg"),
+            ),
         ):
             with caplog.at_level(logging.WARNING):
                 pub.publish_package(pkg_dir)  # must not raise
@@ -258,15 +260,16 @@ class TestPublishPackage:
         (pkg_dir / "package.json").write_text(self._PKG_JSON)
 
         pub = self._publisher_with_repo()
-        conflict = subprocess.CalledProcessError(
-            1, "npm", stderr="E409 conflict"
-        )
+        from unity_wrapper.utils.package_publisher import _PublishConflict
 
         with (
             patch.object(pub, "_copy_package"),
             patch.object(pub, "_update_package_json"),
-            patch.object(pub, "_configure_npm"),
-            patch.object(pub, "_npm_publish", side_effect=conflict),
+            patch.object(
+                pub,
+                "_github_publish_direct",
+                side_effect=_PublishConflict("pkg"),
+            ),
         ):
             pub.publish_package(pkg_dir)  # should not raise
 
@@ -276,17 +279,18 @@ class TestPublishPackage:
         (pkg_dir / "package.json").write_text(self._PKG_JSON)
 
         pub = self._publisher_with_repo()
-        auth_err = subprocess.CalledProcessError(
-            1, "npm", stderr="ENEEDAUTH need auth"
-        )
+        import requests as req
 
         with (
             patch.object(pub, "_copy_package"),
             patch.object(pub, "_update_package_json"),
-            patch.object(pub, "_configure_npm"),
-            patch.object(pub, "_npm_publish", side_effect=auth_err),
+            patch.object(
+                pub,
+                "_github_publish_direct",
+                side_effect=req.HTTPError(response=MagicMock(status_code=401)),
+            ),
         ):
-            with pytest.raises(subprocess.CalledProcessError):
+            with pytest.raises(req.HTTPError):
                 pub.publish_package(pkg_dir)
 
     def test_missing_package_json_raises(self, tmp_path: Path) -> None:
@@ -317,14 +321,6 @@ class TestUpdatePackageJson:
         pkg = self._read_pkg(tmp_path)
         assert pkg["name"] == "com.foo.bar"
 
-    def test_github_adds_publish_config(self, tmp_path: Path) -> None:
-        self._write_pkg(tmp_path)
-        pub = _make_publisher(registry="github", owner="myorg")
-        pub._update_package_json(tmp_path / "package.json")
-        pkg = self._read_pkg(tmp_path)
-        assert "publishConfig" in pkg
-        assert "npm.pkg.github.com" in pkg["publishConfig"]["registry"]
-
     def test_github_adds_repository_field(self, tmp_path: Path) -> None:
         self._write_pkg(tmp_path)
         pub = _make_publisher(registry="github", owner="myorg")
@@ -332,6 +328,14 @@ class TestUpdatePackageJson:
         pkg = self._read_pkg(tmp_path)
         assert pkg["repository"]["type"] == "git"
         assert "myorg" in pkg["repository"]["url"]
+
+    def test_github_no_publish_config(self, tmp_path: Path) -> None:
+        """publishConfig is not needed: we PUT directly with the scoped URL."""
+        self._write_pkg(tmp_path)
+        pub = _make_publisher(registry="github", owner="myorg")
+        pub._update_package_json(tmp_path / "package.json")
+        pkg = self._read_pkg(tmp_path)
+        assert "publishConfig" not in pkg
 
     def test_npmjs_scopes_name(self, tmp_path: Path) -> None:
         """npmjs registry MUST scope the name."""
@@ -350,15 +354,16 @@ class TestUpdatePackageJson:
 
 
 class TestPublishPackageUpmNames:
-    """Verify publish_package logs the unscoped name for GitHub."""
+    """Verify publish_package logs the scoped name for all registries."""
 
     _PKG_JSON = json.dumps({"name": "com.foo.bar", "version": "1.0.0"})
 
-    def test_github_logs_unscoped_name(
+    def test_github_logs_scoped_name(
         self,
         caplog: pytest.LogCaptureFixture,
         tmp_path: Path,
     ) -> None:
+        """GitHub uses direct HTTP publish; name is scoped in the registry."""
         pkg_dir = tmp_path / "pkg"
         pkg_dir.mkdir()
         (pkg_dir / "package.json").write_text(self._PKG_JSON)
@@ -369,14 +374,12 @@ class TestPublishPackageUpmNames:
         with (
             patch.object(pub, "_copy_package"),
             patch.object(pub, "_update_package_json"),
-            patch.object(pub, "_configure_npm"),
-            patch.object(pub, "_npm_publish"),
+            patch.object(pub, "_github_publish_direct"),
         ):
             with caplog.at_level(logging.INFO):
                 pub.publish_package(pkg_dir)
 
-        assert "com.foo.bar@1.0.0" in caplog.text
-        assert "@testowner/com.foo.bar" not in caplog.text
+        assert "@testowner/com.foo.bar@1.0.0" in caplog.text
 
     def test_npmjs_logs_scoped_name(
         self,
@@ -402,9 +405,10 @@ class TestPublishPackageUpmNames:
 
 
 class TestCheckPackageExistsUpmNames:
-    """check_package_exists queries GitHub with the unscoped name."""
+    """check_package_exists always uses the scoped name."""
 
-    def test_github_uses_unscoped_name(self) -> None:
+    def test_github_uses_scoped_name(self) -> None:
+        """GitHub packages are stored under @owner/name in the registry."""
         pub = _make_publisher(registry="github", owner="myorg")
 
         with patch("subprocess.run") as mock_run:
@@ -412,8 +416,7 @@ class TestCheckPackageExistsUpmNames:
             pub.check_package_exists("com.foo.bar", "1.0.0")
             call_args = " ".join(mock_run.call_args[0][0])
 
-        assert "com.foo.bar" in call_args
-        assert "@myorg/com.foo.bar" not in call_args
+        assert "@myorg/com.foo.bar" in call_args
 
     def test_npmjs_uses_scoped_name(self) -> None:
         pub = _make_publisher(registry="npmjs", owner="myorg")
@@ -427,27 +430,7 @@ class TestCheckPackageExistsUpmNames:
 
 
 class TestNpmPublishScope:
-    """_npm_publish passes --scope=@owner for GitHub, not for others."""
-
-    def test_github_with_owner_passes_scope_flag(self) -> None:
-        pub = _make_publisher(registry="github", owner="myorg")
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=0, stdout="", stderr=""
-            )
-            pub._npm_publish(Path("/tmp/pkg"))
-            cmd = mock_run.call_args[0][0]
-        assert "--scope=@myorg" in cmd
-
-    def test_github_without_owner_omits_scope_flag(self) -> None:
-        pub = _make_publisher(registry="github", owner="")
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=0, stdout="", stderr=""
-            )
-            pub._npm_publish(Path("/tmp/pkg"))
-            cmd = mock_run.call_args[0][0]
-        assert not any(a.startswith("--scope") for a in cmd)
+    """_npm_publish does not pass --scope (GitHub uses direct HTTP now)."""
 
     def test_npmjs_omits_scope_flag(self) -> None:
         pub = _make_publisher(registry="npmjs", owner="myorg")
@@ -458,3 +441,83 @@ class TestNpmPublishScope:
             pub._npm_publish(Path("/tmp/pkg"))
             cmd = mock_run.call_args[0][0]
         assert not any(a.startswith("--scope") for a in cmd)
+
+    def test_npmjs_uses_npm_publish_command(self) -> None:
+        pub = _make_publisher(registry="npmjs", owner="myorg")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="", stderr=""
+            )
+            pub._npm_publish(Path("/tmp/pkg"))
+            cmd = mock_run.call_args[0][0]
+        assert cmd[:2] == ["npm", "publish"]
+
+
+class TestGithubPublishDirect:
+    """_github_publish_direct sends a scoped PUT to GitHub Packages."""
+
+    _PKG_JSON = json.dumps({"name": "com.foo.bar", "version": "1.0.0"})
+
+    def _setup_pkg(self, path: Path) -> None:
+        (path / "package.json").write_text(self._PKG_JSON)
+
+    @patch("unity_wrapper.utils.package_publisher.http_requests.put")
+    def test_puts_to_scoped_url(
+        self, mock_put: MagicMock, tmp_path: Path
+    ) -> None:
+        self._setup_pkg(tmp_path)
+        pub = _make_publisher(registry="github", owner="myorg")
+        mock_put.return_value = MagicMock(status_code=200)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="com.foo.bar-1.0.0.tgz\n",
+                stderr="",
+            )
+            with patch("pathlib.Path.read_bytes", return_value=b"x"):
+                pub._github_publish_direct(tmp_path)
+
+        called_url = mock_put.call_args[0][0]
+        assert called_url == ("https://npm.pkg.github.com/@myorg/com.foo.bar")
+
+    @patch("unity_wrapper.utils.package_publisher.http_requests.put")
+    def test_packument_body_has_scoped_name(
+        self, mock_put: MagicMock, tmp_path: Path
+    ) -> None:
+        self._setup_pkg(tmp_path)
+        pub = _make_publisher(registry="github", owner="myorg")
+        mock_put.return_value = MagicMock(status_code=200)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="com.foo.bar-1.0.0.tgz\n",
+                stderr="",
+            )
+            with patch("pathlib.Path.read_bytes", return_value=b"x"):
+                pub._github_publish_direct(tmp_path)
+
+        body = mock_put.call_args[1]["json"]
+        assert body["name"] == "@myorg/com.foo.bar"
+        assert body["versions"]["1.0.0"]["name"] == "@myorg/com.foo.bar"
+
+    @patch("unity_wrapper.utils.package_publisher.http_requests.put")
+    def test_conflict_raises_publish_conflict(
+        self, mock_put: MagicMock, tmp_path: Path
+    ) -> None:
+        from unity_wrapper.utils.package_publisher import _PublishConflict
+
+        self._setup_pkg(tmp_path)
+        pub = _make_publisher(registry="github", owner="myorg")
+        mock_put.return_value = MagicMock(status_code=409)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="com.foo.bar-1.0.0.tgz\n",
+                stderr="",
+            )
+            with patch("pathlib.Path.read_bytes", return_value=b"x"):
+                with pytest.raises(_PublishConflict):
+                    pub._github_publish_direct(tmp_path)

--- a/tests/test_package_publisher.py
+++ b/tests/test_package_publisher.py
@@ -523,3 +523,88 @@ class TestGithubPublishDirect:
             with patch("pathlib.Path.read_bytes", return_value=b"x"):
                 with pytest.raises(_PublishConflict):
                     pub._github_publish_direct(tmp_path)
+
+    @patch("unity_wrapper.utils.package_publisher.http_requests.put")
+    def test_pages_publisher_called_on_success(
+        self, mock_put: MagicMock, tmp_path: Path
+    ) -> None:
+        """PagesPublisher.update_registry is called after a successful PUT."""
+        self._setup_pkg(tmp_path)
+        pub = _make_publisher(registry="github", owner="myorg")
+        mock_put.return_value = MagicMock(status_code=200)
+        registry_dir = tmp_path / "registry"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="com.foo.bar-1.0.0.tgz\n",
+                stderr="",
+            )
+            with patch("pathlib.Path.read_bytes", return_value=b"x"):
+                with patch(
+                    "unity_wrapper.utils.package_publisher"
+                    ".PagesPublisher.update_registry"
+                ) as mock_pages:
+                    pub._github_publish_direct(
+                        tmp_path, registry_dir=registry_dir
+                    )
+
+        mock_pages.assert_called_once()
+        call_kwargs = mock_pages.call_args[1]
+        assert call_kwargs["unscoped_name"] == "com.foo.bar"
+        assert call_kwargs["version"] == "1.0.0"
+        assert call_kwargs["registry_dir"] == registry_dir
+
+    @patch("unity_wrapper.utils.package_publisher.http_requests.put")
+    def test_pages_publisher_skipped_when_no_registry_dir(
+        self, mock_put: MagicMock, tmp_path: Path
+    ) -> None:
+        """PagesPublisher is not called when registry_dir is None."""
+        self._setup_pkg(tmp_path)
+        pub = _make_publisher(registry="github", owner="myorg")
+        mock_put.return_value = MagicMock(status_code=200)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="com.foo.bar-1.0.0.tgz\n",
+                stderr="",
+            )
+            with patch("pathlib.Path.read_bytes", return_value=b"x"):
+                with patch(
+                    "unity_wrapper.utils.package_publisher"
+                    ".PagesPublisher.update_registry"
+                ) as mock_pages:
+                    pub._github_publish_direct(tmp_path, registry_dir=None)
+
+        mock_pages.assert_not_called()
+
+    @patch("unity_wrapper.utils.package_publisher.http_requests.put")
+    def test_pages_publisher_called_on_conflict(
+        self, mock_put: MagicMock, tmp_path: Path
+    ) -> None:
+        """Static packument is written even when GitHub returns 409."""
+        from unity_wrapper.utils.package_publisher import _PublishConflict
+
+        self._setup_pkg(tmp_path)
+        pub = _make_publisher(registry="github", owner="myorg")
+        mock_put.return_value = MagicMock(status_code=409)
+        registry_dir = tmp_path / "registry"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="com.foo.bar-1.0.0.tgz\n",
+                stderr="",
+            )
+            with patch("pathlib.Path.read_bytes", return_value=b"x"):
+                with patch(
+                    "unity_wrapper.utils.package_publisher"
+                    ".PagesPublisher.update_registry"
+                ) as mock_pages:
+                    with pytest.raises(_PublishConflict):
+                        pub._github_publish_direct(
+                            tmp_path, registry_dir=registry_dir
+                        )
+
+        mock_pages.assert_called_once()

--- a/tests/test_package_publisher.py
+++ b/tests/test_package_publisher.py
@@ -5,6 +5,7 @@ import logging
 import os
 import subprocess
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -292,3 +293,134 @@ class TestPublishPackage:
         pub = self._publisher_with_repo()
         with pytest.raises(FileNotFoundError, match="package.json not found"):
             pub.publish_package(tmp_path / "nonexistent")
+
+
+class TestUpdatePackageJson:
+    """Verify _update_package_json UPM-compatible name handling."""
+
+    def _write_pkg(self, path: Path, name: str = "com.foo.bar") -> None:
+        (path / "package.json").write_text(
+            json.dumps({"name": name, "version": "1.0.0"})
+        )
+
+    def _read_pkg(self, path: Path) -> dict[str, Any]:
+        result: dict[str, Any] = json.loads(
+            (path / "package.json").read_text()
+        )
+        return result
+
+    def test_github_keeps_unscoped_name(self, tmp_path: Path) -> None:
+        """GitHub registry must NOT scope the name so UPM can resolve it."""
+        self._write_pkg(tmp_path)
+        pub = _make_publisher(registry="github", owner="myorg")
+        pub._update_package_json(tmp_path / "package.json")
+        pkg = self._read_pkg(tmp_path)
+        assert pkg["name"] == "com.foo.bar"
+
+    def test_github_adds_publish_config(self, tmp_path: Path) -> None:
+        self._write_pkg(tmp_path)
+        pub = _make_publisher(registry="github", owner="myorg")
+        pub._update_package_json(tmp_path / "package.json")
+        pkg = self._read_pkg(tmp_path)
+        assert "publishConfig" in pkg
+        assert "npm.pkg.github.com" in pkg["publishConfig"]["registry"]
+
+    def test_github_adds_repository_field(self, tmp_path: Path) -> None:
+        self._write_pkg(tmp_path)
+        pub = _make_publisher(registry="github", owner="myorg")
+        pub._update_package_json(tmp_path / "package.json")
+        pkg = self._read_pkg(tmp_path)
+        assert pkg["repository"]["type"] == "git"
+        assert "myorg" in pkg["repository"]["url"]
+
+    def test_npmjs_scopes_name(self, tmp_path: Path) -> None:
+        """npmjs registry MUST scope the name."""
+        self._write_pkg(tmp_path)
+        pub = _make_publisher(registry="npmjs", owner="myorg")
+        pub._update_package_json(tmp_path / "package.json")
+        pkg = self._read_pkg(tmp_path)
+        assert pkg["name"] == "@myorg/com.foo.bar"
+
+    def test_npmjs_no_publish_config(self, tmp_path: Path) -> None:
+        self._write_pkg(tmp_path)
+        pub = _make_publisher(registry="npmjs", owner="myorg")
+        pub._update_package_json(tmp_path / "package.json")
+        pkg = self._read_pkg(tmp_path)
+        assert "publishConfig" not in pkg
+
+
+class TestPublishPackageUpmNames:
+    """Verify publish_package logs the unscoped name for GitHub."""
+
+    _PKG_JSON = json.dumps({"name": "com.foo.bar", "version": "1.0.0"})
+
+    def test_github_logs_unscoped_name(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        tmp_path: Path,
+    ) -> None:
+        pkg_dir = tmp_path / "pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "package.json").write_text(self._PKG_JSON)
+
+        pub = _make_publisher(registry="github")
+        pub.repo = "my-wrappers"
+
+        with (
+            patch.object(pub, "_copy_package"),
+            patch.object(pub, "_update_package_json"),
+            patch.object(pub, "_configure_npm"),
+            patch.object(pub, "_npm_publish"),
+        ):
+            with caplog.at_level(logging.INFO):
+                pub.publish_package(pkg_dir)
+
+        assert "com.foo.bar@1.0.0" in caplog.text
+        assert "@testowner/com.foo.bar" not in caplog.text
+
+    def test_npmjs_logs_scoped_name(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        tmp_path: Path,
+    ) -> None:
+        pkg_dir = tmp_path / "pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "package.json").write_text(self._PKG_JSON)
+
+        pub = _make_publisher(registry="npmjs")
+
+        with (
+            patch.object(pub, "_copy_package"),
+            patch.object(pub, "_update_package_json"),
+            patch.object(pub, "_configure_npm"),
+            patch.object(pub, "_npm_publish"),
+        ):
+            with caplog.at_level(logging.INFO):
+                pub.publish_package(pkg_dir)
+
+        assert "@testowner/com.foo.bar@1.0.0" in caplog.text
+
+
+class TestCheckPackageExistsUpmNames:
+    """check_package_exists queries GitHub with the unscoped name."""
+
+    def test_github_uses_unscoped_name(self) -> None:
+        pub = _make_publisher(registry="github", owner="myorg")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="1.0.0")
+            pub.check_package_exists("com.foo.bar", "1.0.0")
+            call_args = " ".join(mock_run.call_args[0][0])
+
+        assert "com.foo.bar" in call_args
+        assert "@myorg/com.foo.bar" not in call_args
+
+    def test_npmjs_uses_scoped_name(self) -> None:
+        pub = _make_publisher(registry="npmjs", owner="myorg")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="1.0.0")
+            pub.check_package_exists("com.foo.bar", "1.0.0")
+            call_args = " ".join(mock_run.call_args[0][0])
+
+        assert "@myorg/com.foo.bar" in call_args

--- a/tests/test_package_publisher.py
+++ b/tests/test_package_publisher.py
@@ -501,6 +501,8 @@ class TestGithubPublishDirect:
         body = mock_put.call_args[1]["json"]
         assert body["name"] == "@myorg/com.foo.bar"
         assert body["versions"]["1.0.0"]["name"] == "@myorg/com.foo.bar"
+        # Attachment key must be scoped name + version for GitHub routing
+        assert "@myorg/com.foo.bar-1.0.0.tgz" in body["_attachments"]
 
     @patch("unity_wrapper.utils.package_publisher.http_requests.put")
     def test_conflict_raises_publish_conflict(

--- a/tests/test_package_publisher.py
+++ b/tests/test_package_publisher.py
@@ -424,3 +424,37 @@ class TestCheckPackageExistsUpmNames:
             call_args = " ".join(mock_run.call_args[0][0])
 
         assert "@myorg/com.foo.bar" in call_args
+
+
+class TestNpmPublishScope:
+    """_npm_publish passes --scope=@owner for GitHub, not for others."""
+
+    def test_github_with_owner_passes_scope_flag(self) -> None:
+        pub = _make_publisher(registry="github", owner="myorg")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="", stderr=""
+            )
+            pub._npm_publish(Path("/tmp/pkg"))
+            cmd = mock_run.call_args[0][0]
+        assert "--scope=@myorg" in cmd
+
+    def test_github_without_owner_omits_scope_flag(self) -> None:
+        pub = _make_publisher(registry="github", owner="")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="", stderr=""
+            )
+            pub._npm_publish(Path("/tmp/pkg"))
+            cmd = mock_run.call_args[0][0]
+        assert not any(a.startswith("--scope") for a in cmd)
+
+    def test_npmjs_omits_scope_flag(self) -> None:
+        pub = _make_publisher(registry="npmjs", owner="myorg")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="", stderr=""
+            )
+            pub._npm_publish(Path("/tmp/pkg"))
+            cmd = mock_run.call_args[0][0]
+        assert not any(a.startswith("--scope") for a in cmd)

--- a/tests/test_pages_publisher.py
+++ b/tests/test_pages_publisher.py
@@ -1,0 +1,190 @@
+"""Tests for PagesPublisher."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from unity_wrapper.utils.pages_publisher import PagesPublisher
+
+
+@pytest.fixture
+def registry_dir(tmp_path: Path) -> Path:
+    return tmp_path / "registry"
+
+
+@pytest.fixture
+def publisher() -> PagesPublisher:
+    return PagesPublisher()
+
+
+_VERSION_META = {
+    "name": "@owner/com.foo.bar",
+    "_id": "@owner/com.foo.bar@1.0.0",
+    "description": "A test package",
+    "version": "1.0.0",
+    "unity": "2019.4",
+}
+
+
+def _write_version(
+    publisher: PagesPublisher,
+    registry_dir: Path,
+    version: str = "1.0.0",
+    name: str = "com.foo.bar",
+) -> Path:
+    return publisher.update_registry(
+        registry_dir=registry_dir,
+        unscoped_name=name,
+        version=version,
+        version_meta=dict(_VERSION_META),
+        tarball_url=(
+            f"https://npm.pkg.github.com/@owner/{name}/-/{name}-{version}.tgz"
+        ),
+        shasum="abc123",
+        integrity="sha512-xxx==",
+        description="A test package",
+    )
+
+
+class TestPagesPublisherCreate:
+    """Creates a new packument file on first call."""
+
+    def test_creates_registry_dir(
+        self,
+        publisher: PagesPublisher,
+        tmp_path: Path,
+    ) -> None:
+        nested = tmp_path / "a" / "b" / "registry"
+        _write_version(publisher, nested)
+        assert nested.exists()
+
+    def test_creates_packument_file(
+        self,
+        publisher: PagesPublisher,
+        registry_dir: Path,
+    ) -> None:
+        path = _write_version(publisher, registry_dir)
+        assert path.exists()
+        assert path.name == "com.foo.bar.json"
+
+    def test_packument_has_unscoped_name(
+        self,
+        publisher: PagesPublisher,
+        registry_dir: Path,
+    ) -> None:
+        _write_version(publisher, registry_dir)
+        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        assert doc["name"] == "com.foo.bar"
+
+    def test_packument_dist_tags_latest(
+        self,
+        publisher: PagesPublisher,
+        registry_dir: Path,
+    ) -> None:
+        _write_version(publisher, registry_dir, version="2.0.0")
+        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        assert doc["dist-tags"]["latest"] == "2.0.0"
+
+    def test_version_entry_has_dist(
+        self,
+        publisher: PagesPublisher,
+        registry_dir: Path,
+    ) -> None:
+        _write_version(publisher, registry_dir, version="1.0.0")
+        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        dist = doc["versions"]["1.0.0"]["dist"]
+        assert dist["shasum"] == "abc123"
+        assert dist["integrity"] == "sha512-xxx=="
+        assert "tarball" in dist
+
+    def test_version_entry_name_is_unscoped(
+        self,
+        publisher: PagesPublisher,
+        registry_dir: Path,
+    ) -> None:
+        """Even if version_meta has scoped name, output must be unscoped."""
+        _write_version(publisher, registry_dir)
+        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        assert doc["versions"]["1.0.0"]["name"] == "com.foo.bar"
+
+    def test_version_entry_id_removed(
+        self,
+        publisher: PagesPublisher,
+        registry_dir: Path,
+    ) -> None:
+        """_id from version_meta (scoped) should not appear in output."""
+        _write_version(publisher, registry_dir)
+        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        assert "_id" not in doc["versions"]["1.0.0"]
+
+
+class TestPagesPublisherUpdate:
+    """Merges new versions into an existing packument file."""
+
+    def test_accumulates_versions(
+        self,
+        publisher: PagesPublisher,
+        registry_dir: Path,
+    ) -> None:
+        _write_version(publisher, registry_dir, version="1.0.0")
+        _write_version(publisher, registry_dir, version="1.1.0")
+        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        assert "1.0.0" in doc["versions"]
+        assert "1.1.0" in doc["versions"]
+
+    def test_latest_tag_updated_to_newest(
+        self,
+        publisher: PagesPublisher,
+        registry_dir: Path,
+    ) -> None:
+        _write_version(publisher, registry_dir, version="1.0.0")
+        _write_version(publisher, registry_dir, version="1.1.0")
+        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        assert doc["dist-tags"]["latest"] == "1.1.0"
+
+    def test_fixes_scoped_name_in_existing_file(
+        self,
+        publisher: PagesPublisher,
+        registry_dir: Path,
+    ) -> None:
+        """If an older file has a scoped name, it gets corrected on update."""
+        registry_dir.mkdir(parents=True)
+        bad = {
+            "name": "@owner/com.foo.bar",
+            "dist-tags": {"latest": "0.9.0"},
+            "versions": {"0.9.0": {"name": "@owner/com.foo.bar"}},
+        }
+        (registry_dir / "com.foo.bar.json").write_text(json.dumps(bad))
+
+        _write_version(publisher, registry_dir, version="1.0.0")
+
+        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        assert doc["name"] == "com.foo.bar"
+        assert "0.9.0" in doc["versions"]  # old version preserved
+        assert "1.0.0" in doc["versions"]  # new version added
+
+
+class TestPagesPublisherTarballUrl:
+    """Tarball URL is stored verbatim in the static packument."""
+
+    def test_tarball_url_preserved(
+        self,
+        publisher: PagesPublisher,
+        registry_dir: Path,
+    ) -> None:
+        expected = (
+            "https://npm.pkg.github.com/@owner/com.foo.bar"
+            "/-/@owner/com.foo.bar-1.0.0.tgz"
+        )
+        publisher.update_registry(
+            registry_dir=registry_dir,
+            unscoped_name="com.foo.bar",
+            version="1.0.0",
+            version_meta=dict(_VERSION_META),
+            tarball_url=expected,
+            shasum="deadbeef",
+            integrity="sha512-yyy==",
+        )
+        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        assert doc["versions"]["1.0.0"]["dist"]["tarball"] == expected

--- a/tests/test_unity_generator.py
+++ b/tests/test_unity_generator.py
@@ -116,3 +116,43 @@ def test_organize_runtime_structure_preserves_existing_structure(
     assert (package_dir / "Runtime" / "MyScript.asmdef").exists()
     assert (package_dir / "Editor" / "EditorScript.cs").exists()
     assert (package_dir / "package.json").exists()
+
+
+class TestGeneratePackageJsonVersion:
+    """generate_package_json strips leading 'v' from version strings."""
+
+    def _make_gen(self, tmp_path: Path) -> UnityGenerator:
+        return UnityGenerator(tmp_path)
+
+    def test_v_prefix_is_stripped(self, tmp_path: Path) -> None:
+        gen = self._make_gen(tmp_path)
+        pkg = gen.generate_package_json(
+            name="com.foo.bar",
+            display_name="Foo",
+            version="v1.2.3",
+            description="",
+            author="Author",
+        )
+        assert pkg["version"] == "1.2.3"
+
+    def test_no_prefix_unchanged(self, tmp_path: Path) -> None:
+        gen = self._make_gen(tmp_path)
+        pkg = gen.generate_package_json(
+            name="com.foo.bar",
+            display_name="Foo",
+            version="1.2.3",
+            description="",
+            author="Author",
+        )
+        assert pkg["version"] == "1.2.3"
+
+    def test_only_leading_v_stripped(self, tmp_path: Path) -> None:
+        gen = self._make_gen(tmp_path)
+        pkg = gen.generate_package_json(
+            name="com.foo.bar",
+            display_name="Foo",
+            version="v31.1.0",
+            description="",
+            author="Author",
+        )
+        assert pkg["version"] == "31.1.0"


### PR DESCRIPTION
## Problem

Unity Package Manager cannot resolve scoped npm names like `@owner/com.foo.bar`. GitHub npm registry requires the `@scope` prefix to route packages correctly, but UPM queries the registry by the exact bare name (e.g. `com.foo.bar`).

Reference: `docs/unity-github-registry-limitations.md`

## Solution

Publish with the **unscoped name** in `package.json`. GitHub infers ownership from the `repository` field and `publishConfig.registry`, so no explicit scope is needed at publish time.

### Changes

- **`_update_package_json`**: Skip `_compute_scoped_name` for `registry == "github"`; keep bare UPM name. Still adds `repository` and `publishConfig.registry`.
- **`publish_package`**: Use unscoped `display_name` for logging when targeting GitHub.
- **`check_package_exists`**: Query GitHub with unscoped package name.
- **Tests**: 13 new tests covering GitHub/npmjs name-handling in `_update_package_json`, `publish_package`, and `check_package_exists`.