### PR TITLE
fix: pass GITHUB_TOKEN env var to publish step in CI

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -154,6 +154,7 @@ jobs:
         if: (steps.check-updates.outputs.updates-needed == 'true' || github.event.inputs.package_name != '') && github.ref == 'refs/heads/main'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Publishing packages to GitHub Package Registry..."
           make publish REGISTRY=github OWNER=${{ github.repository_owner }}


### PR DESCRIPTION
The CI publish step only set NODE_AUTH_TOKEN but the Python publisher reads GITHUB_TOKEN from env. Added GITHUB_TOKEN to the publish step env vars.