### PR TITLE
fix: use actual repo URL in packument and fail CI on publish errors

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -159,18 +159,29 @@ jobs:
           echo "Publishing packages to GitHub Package Registry..."
           make publish REGISTRY=github OWNER=${{ github.repository_owner }}
 
+      - name: Check if static registry was generated
+        id: check-registry
+        if: github.ref == 'refs/heads/main'
+        run: |
+          if [ -d "dist/registry" ] && [ "$(ls -A dist/registry)" ]; then
+            echo "registry-exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "registry-exists=false" >> $GITHUB_OUTPUT
+            echo "dist/registry/ not found or empty, skipping Pages deploy"
+          fi
+
       - name: Configure GitHub Pages
-        if: (steps.check-updates.outputs.updates-needed == 'true' || github.event.inputs.package_name != '') && github.ref == 'refs/heads/main'
+        if: steps.check-registry.outputs.registry-exists == 'true'
         uses: actions/configure-pages@v4
 
       - name: Upload static registry to GitHub Pages
-        if: (steps.check-updates.outputs.updates-needed == 'true' || github.event.inputs.package_name != '') && github.ref == 'refs/heads/main'
+        if: steps.check-registry.outputs.registry-exists == 'true'
         uses: actions/upload-pages-artifact@v3
         with:
           path: dist/registry/
 
       - name: Deploy static registry to GitHub Pages
-        if: (steps.check-updates.outputs.updates-needed == 'true' || github.event.inputs.package_name != '') && github.ref == 'refs/heads/main'
+        if: steps.check-registry.outputs.registry-exists == 'true'
         uses: actions/deploy-pages@v4
 
   test:

--- a/src/unity_wrapper/cli.py
+++ b/src/unity_wrapper/cli.py
@@ -217,6 +217,7 @@ def publish(
         else:
             click.echo("Publishing all packages...")
             published_count = 0
+            failed_count = 0
 
             for package_dir in output_path.iterdir():
                 if (
@@ -232,8 +233,15 @@ def publish(
                             f"Failed to publish {package_dir.name}: {e}",
                             err=True,
                         )
+                        failed_count += 1
 
             click.echo(f"Successfully published {published_count} packages")
+            if failed_count:
+                click.echo(
+                    f"{failed_count} package(s) failed to publish.",
+                    err=True,
+                )
+                sys.exit(1)
 
     except Exception as e:
         click.echo(f"Error publishing packages: {e}", err=True)

--- a/src/unity_wrapper/utils/package_publisher.py
+++ b/src/unity_wrapper/utils/package_publisher.py
@@ -270,12 +270,16 @@ class PackagePublisher:
             package_json["name"] = self._compute_scoped_name(original_name)
 
         if self.owner and self.registry in ["github", "npmjs"]:
-            package_json["repository"] = {
-                "type": "git",
-                "url": (
+            if self.registry == "github" and self.repo:
+                repo_url = f"https://github.com/{self.owner}/{self.repo}.git"
+            else:
+                repo_url = (
                     f"https://github.com/{self.owner}/"
                     f"{original_name}.package-wrappers-unity.git"
-                ),
+                )
+            package_json["repository"] = {
+                "type": "git",
+                "url": repo_url,
             }
 
         with open(package_json_path, "w", encoding="utf-8") as f:

--- a/tests/test_package_publisher.py
+++ b/tests/test_package_publisher.py
@@ -329,6 +329,28 @@ class TestUpdatePackageJson:
         assert pkg["repository"]["type"] == "git"
         assert "myorg" in pkg["repository"]["url"]
 
+    def test_github_uses_actual_repo_when_available(
+        self, tmp_path: Path
+    ) -> None:
+        """When GITHUB_REPOSITORY is set, repository.url points to it."""
+        self._write_pkg(tmp_path)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="10.0.0", returncode=0)
+            with patch.dict(
+                os.environ,
+                {"GITHUB_REPOSITORY": "myorg/package-wrappers-unity"},
+                clear=False,
+            ):
+                pub = PackagePublisher(
+                    registry="github", token="tok", owner="myorg"
+                )
+        pub._update_package_json(tmp_path / "package.json")
+        pkg = self._read_pkg(tmp_path)
+        assert (
+            pkg["repository"]["url"]
+            == "https://github.com/myorg/package-wrappers-unity.git"
+        )
+
     def test_github_no_publish_config(self, tmp_path: Path) -> None:
         """publishConfig is not needed: we PUT directly with the scoped URL."""
         self._write_pkg(tmp_path)


### PR DESCRIPTION
## Changes

- **Fix 403 on GitHub Packages**: Set `repository.url` in the packument to the actual publishing repo (`https://github.com/owner/repo.git` via `GITHUB_REPOSITORY` env var) instead of a fabricated per-package URL. This allows GitHub Packages to associate the package with the workflow repo so `GITHUB_TOKEN` can update it.

- **Fix silent CI failure**: The `publish` CLI command now exits with code 1 if any packages fail to publish, so CI correctly reports failures instead of silently succeeding with 0 published packages.

- **Fix Pages upload failure**: Made the Pages upload/deploy steps conditional on `dist/registry/` existing, avoiding a spurious `tar` failure when publish fails or is skipped.

- **New test**: Added `test_github_uses_actual_repo_when_available` to assert that `repository.url` points to the actual repo when `GITHUB_REPOSITORY` is set.