### PR TITLE
ci: use PACKAGES_PAT for publishing to GitHub Packages

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -153,8 +153,8 @@ jobs:
       - name: Publish packages to GitHub Package Registry
         if: (steps.check-updates.outputs.updates-needed == 'true' || github.event.inputs.package_name != '') && github.ref == 'refs/heads/main'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_PAT }}
+          GITHUB_TOKEN: ${{ secrets.PACKAGES_PAT }}
         run: |
           echo "Publishing packages to GitHub Package Registry..."
           make publish REGISTRY=github OWNER=${{ github.repository_owner }}


### PR DESCRIPTION
## Problem

`GITHUB_TOKEN` can only update packages that were originally created by a GitHub Actions workflow (or explicitly granted access in package settings). Packages published locally with a PAT are user-owned and not linked to the repository, so `GITHUB_TOKEN` gets 403.

## Fix

Store the PAT (`write:packages` scope) as the `PACKAGES_PAT` repo secret (already done) and use it for the publish step.

## Testing

Will verify by triggering the workflow for `com.klumhru.wrapper.google-protobuf` after merge.