### PR TITLE
fix: write packument files without .json extension for UPM compatibility

### DIFF
--- a/src/unity_wrapper/utils/pages_publisher.py
+++ b/src/unity_wrapper/utils/pages_publisher.py
@@ -29,7 +29,8 @@ class PagesPublisher:
     """Generates static npm packument files for a GitHub Pages registry.
 
     Each package gets a single JSON file at
-    ``{registry_dir}/{package_name}.json`` following the npm packument
+    ``{registry_dir}/{package_name}`` (no file extension) following the
+    npm packument
     format.  Multiple versions accumulate in the same file; the
     ``dist-tags.latest`` tag always points to the most-recently-added
     version.
@@ -83,7 +84,7 @@ class PagesPublisher:
             Path to the written packument JSON file.
         """
         registry_dir.mkdir(parents=True, exist_ok=True)
-        packument_path = registry_dir / f"{unscoped_name}.json"
+        packument_path = registry_dir / unscoped_name
 
         packument = self._load_or_create(
             packument_path, unscoped_name, description

--- a/tests/test_pages_publisher.py
+++ b/tests/test_pages_publisher.py
@@ -66,7 +66,7 @@ class TestPagesPublisherCreate:
     ) -> None:
         path = _write_version(publisher, registry_dir)
         assert path.exists()
-        assert path.name == "com.foo.bar.json"
+        assert path.name == "com.foo.bar"
 
     def test_packument_has_unscoped_name(
         self,
@@ -74,7 +74,7 @@ class TestPagesPublisherCreate:
         registry_dir: Path,
     ) -> None:
         _write_version(publisher, registry_dir)
-        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        doc = json.loads((registry_dir / "com.foo.bar").read_text())
         assert doc["name"] == "com.foo.bar"
 
     def test_packument_dist_tags_latest(
@@ -83,7 +83,7 @@ class TestPagesPublisherCreate:
         registry_dir: Path,
     ) -> None:
         _write_version(publisher, registry_dir, version="2.0.0")
-        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        doc = json.loads((registry_dir / "com.foo.bar").read_text())
         assert doc["dist-tags"]["latest"] == "2.0.0"
 
     def test_version_entry_has_dist(
@@ -92,7 +92,7 @@ class TestPagesPublisherCreate:
         registry_dir: Path,
     ) -> None:
         _write_version(publisher, registry_dir, version="1.0.0")
-        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        doc = json.loads((registry_dir / "com.foo.bar").read_text())
         dist = doc["versions"]["1.0.0"]["dist"]
         assert dist["shasum"] == "abc123"
         assert dist["integrity"] == "sha512-xxx=="
@@ -105,7 +105,7 @@ class TestPagesPublisherCreate:
     ) -> None:
         """Even if version_meta has scoped name, output must be unscoped."""
         _write_version(publisher, registry_dir)
-        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        doc = json.loads((registry_dir / "com.foo.bar").read_text())
         assert doc["versions"]["1.0.0"]["name"] == "com.foo.bar"
 
     def test_version_entry_id_removed(
@@ -115,7 +115,7 @@ class TestPagesPublisherCreate:
     ) -> None:
         """_id from version_meta (scoped) should not appear in output."""
         _write_version(publisher, registry_dir)
-        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        doc = json.loads((registry_dir / "com.foo.bar").read_text())
         assert "_id" not in doc["versions"]["1.0.0"]
 
 
@@ -129,7 +129,7 @@ class TestPagesPublisherUpdate:
     ) -> None:
         _write_version(publisher, registry_dir, version="1.0.0")
         _write_version(publisher, registry_dir, version="1.1.0")
-        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        doc = json.loads((registry_dir / "com.foo.bar").read_text())
         assert "1.0.0" in doc["versions"]
         assert "1.1.0" in doc["versions"]
 
@@ -140,7 +140,7 @@ class TestPagesPublisherUpdate:
     ) -> None:
         _write_version(publisher, registry_dir, version="1.0.0")
         _write_version(publisher, registry_dir, version="1.1.0")
-        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        doc = json.loads((registry_dir / "com.foo.bar").read_text())
         assert doc["dist-tags"]["latest"] == "1.1.0"
 
     def test_fixes_scoped_name_in_existing_file(
@@ -155,11 +155,11 @@ class TestPagesPublisherUpdate:
             "dist-tags": {"latest": "0.9.0"},
             "versions": {"0.9.0": {"name": "@owner/com.foo.bar"}},
         }
-        (registry_dir / "com.foo.bar.json").write_text(json.dumps(bad))
+        (registry_dir / "com.foo.bar").write_text(json.dumps(bad))
 
         _write_version(publisher, registry_dir, version="1.0.0")
 
-        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        doc = json.loads((registry_dir / "com.foo.bar").read_text())
         assert doc["name"] == "com.foo.bar"
         assert "0.9.0" in doc["versions"]  # old version preserved
         assert "1.0.0" in doc["versions"]  # new version added
@@ -186,5 +186,5 @@ class TestPagesPublisherTarballUrl:
             shasum="deadbeef",
             integrity="sha512-yyy==",
         )
-        doc = json.loads((registry_dir / "com.foo.bar.json").read_text())
+        doc = json.loads((registry_dir / "com.foo.bar").read_text())
         assert doc["versions"]["1.0.0"]["dist"]["tarball"] == expected


### PR DESCRIPTION
UPM requests packuments at the bare package name URL (e.g. `/com.foo.bar`), not with a `.json` extension. Files named `com.foo.bar.json` were served at the wrong URL.

## Verified
- `https://klumhru.github.io/package-wrappers-unity/com.klumhru.wrapper.google-protobuf.json` → 200 (current, wrong URL)
- After this fix, files will be served at `/com.klumhru.wrapper.google-protobuf` (correct URL for UPM)