### PR TITLE
fix: fetch real tarball URL from GitHub Packages for Pages packument

### DIFF
--- a/src/unity_wrapper/utils/package_publisher.py
+++ b/src/unity_wrapper/utils/package_publisher.py
@@ -394,12 +394,15 @@ class PackagePublisher:
             # the Pages packument stays current (e.g. on first run after
             # adding PagesPublisher, or after a manual re-publish).
             if registry_dir is not None:
+                real_url = self._fetch_github_tarball_url(
+                    scoped_name, version, headers
+                )
                 PagesPublisher().update_registry(
                     registry_dir=registry_dir,
                     unscoped_name=original_name,
                     version=version,
                     version_meta=version_meta,
-                    tarball_url=tarball_url,
+                    tarball_url=real_url or tarball_url,
                     shasum=shasum,
                     integrity=integrity,
                     description=pkg_data.get("description"),
@@ -410,16 +413,58 @@ class PackagePublisher:
         logger.debug(f"GitHub publish HTTP status: {response.status_code}")
 
         if registry_dir is not None:
+            real_url = self._fetch_github_tarball_url(
+                scoped_name, version, headers
+            )
             PagesPublisher().update_registry(
                 registry_dir=registry_dir,
                 unscoped_name=original_name,
                 version=version,
                 version_meta=version_meta,
-                tarball_url=tarball_url,
+                tarball_url=real_url or tarball_url,
                 shasum=shasum,
                 integrity=integrity,
                 description=pkg_data.get("description"),
             )
+
+    def _fetch_github_tarball_url(
+        self,
+        scoped_name: str,
+        version: str,
+        headers: Dict[str, str],
+    ) -> Optional[str]:
+        """Fetch the real tarball URL from GitHub Packages for a version.
+
+        GitHub Packages uses a ``/download/...`` URL format that differs
+        from the standard npm ``/-/name-version.tgz`` path.  This method
+        queries the packument to obtain the authoritative download URL.
+
+        Args:
+            scoped_name: Scoped package name (e.g. ``@owner/com.foo.bar``).
+            version: Version string (e.g. ``1.2.3``).
+            headers: HTTP headers including Bearer auth token.
+
+        Returns:
+            Real tarball URL from GitHub Packages, or ``None`` on failure.
+        """
+        try:
+            url = f"{self.config['url']}/{scoped_name}"
+            resp = http_requests.get(url, headers=headers, timeout=30)
+            resp.raise_for_status()
+            data: Dict[str, Any] = resp.json()
+            tarball: Optional[str] = (
+                data.get("versions", {})
+                .get(version, {})
+                .get("dist", {})
+                .get("tarball")
+            )
+            return tarball
+        except Exception as exc:
+            logger.warning(
+                f"Could not fetch real tarball URL for "
+                f"{scoped_name}@{version}: {exc}"
+            )
+            return None
 
     def _npm_publish(self, package_dir: Path) -> None:
         """Publish package using npm (non-GitHub registries)."""

--- a/tests/test_package_publisher.py
+++ b/tests/test_package_publisher.py
@@ -630,3 +630,79 @@ class TestGithubPublishDirect:
                         )
 
         mock_pages.assert_called_once()
+
+    @patch("unity_wrapper.utils.package_publisher.http_requests.get")
+    @patch("unity_wrapper.utils.package_publisher.http_requests.put")
+    def test_pages_uses_real_tarball_url_from_github(
+        self,
+        mock_put: MagicMock,
+        mock_get: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Pages packument tarball_url comes from GitHub Packages GET."""
+        self._setup_pkg(tmp_path)
+        pub = _make_publisher(registry="github", owner="myorg")
+        mock_put.return_value = MagicMock(status_code=200)
+        real_url = (
+            "https://npm.pkg.github.com/download/"
+            "@myorg/com.foo.bar/1.0.0/abc123"
+        )
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {
+                "versions": {"1.0.0": {"dist": {"tarball": real_url}}}
+            },
+        )
+        registry_dir = tmp_path / "registry"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="com.foo.bar-1.0.0.tgz\n",
+                stderr="",
+            )
+            with patch("pathlib.Path.read_bytes", return_value=b"x"):
+                with patch(
+                    "unity_wrapper.utils.package_publisher"
+                    ".PagesPublisher.update_registry"
+                ) as mock_pages:
+                    pub._github_publish_direct(
+                        tmp_path, registry_dir=registry_dir
+                    )
+
+        call_kwargs = mock_pages.call_args[1]
+        assert call_kwargs["tarball_url"] == real_url
+
+    @patch("unity_wrapper.utils.package_publisher.http_requests.get")
+    @patch("unity_wrapper.utils.package_publisher.http_requests.put")
+    def test_pages_falls_back_to_constructed_url_when_get_fails(
+        self,
+        mock_put: MagicMock,
+        mock_get: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Falls back to constructed tarball URL when GitHub GET fails."""
+        self._setup_pkg(tmp_path)
+        pub = _make_publisher(registry="github", owner="myorg")
+        mock_put.return_value = MagicMock(status_code=200)
+        mock_get.side_effect = Exception("network error")
+        registry_dir = tmp_path / "registry"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="com.foo.bar-1.0.0.tgz\n",
+                stderr="",
+            )
+            with patch("pathlib.Path.read_bytes", return_value=b"x"):
+                with patch(
+                    "unity_wrapper.utils.package_publisher"
+                    ".PagesPublisher.update_registry"
+                ) as mock_pages:
+                    pub._github_publish_direct(
+                        tmp_path, registry_dir=registry_dir
+                    )
+
+        call_kwargs = mock_pages.call_args[1]
+        # Falls back to constructed /-/ URL
+        assert "/-/" in call_kwargs["tarball_url"]


### PR DESCRIPTION
GitHub Packages serves tarballs at `/download/@scope/pkg/version/hash`, not the standard `/-/name-version.tgz` path. The constructed URL returned **405**, preventing UPM from downloading the package.

After publishing (or on 409), query the GitHub Packages packument to get the real URL. Falls back to the constructed URL on error.