### PR TITLE
fix: serve tarballs from GitHub Pages to avoid UPM auth failure

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -169,13 +169,6 @@ jobs:
           echo "Publishing packages to GitHub Package Registry..."
           make publish REGISTRY=github OWNER=${{ github.repository_owner }}
 
-      - name: Save Pages registry cache
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v4
-        with:
-          path: dist/registry
-          key: pages-registry-${{ github.run_id }}
-
       - name: Check if static registry was generated
         id: check-registry
         if: github.ref == 'refs/heads/main'
@@ -186,6 +179,13 @@ jobs:
             echo "registry-exists=false" >> $GITHUB_OUTPUT
             echo "dist/registry/ not found or empty, skipping Pages deploy"
           fi
+
+      - name: Save Pages registry cache
+        if: steps.check-registry.outputs.registry-exists == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: dist/registry
+          key: pages-registry-${{ github.run_id }}
 
       - name: Configure GitHub Pages
         if: steps.check-registry.outputs.registry-exists == 'true'

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -117,6 +117,15 @@ jobs:
           node-version: '18'
           registry-url: 'https://npm.pkg.github.com'
 
+      - name: Restore Pages registry cache
+        if: (steps.check-updates.outputs.updates-needed == 'true' || github.event.inputs.package_name != '') && github.ref == 'refs/heads/main'
+        uses: actions/cache/restore@v4
+        with:
+          path: dist/registry
+          key: pages-registry-${{ github.run_id }}
+          restore-keys: |
+            pages-registry-
+
       - name: Create settings file for CI
         if: (steps.check-updates.outputs.updates-needed == 'true' || github.event.inputs.package_name != '') && github.ref == 'refs/heads/main'
         run: |
@@ -155,9 +164,17 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_PAT }}
           GITHUB_TOKEN: ${{ secrets.PACKAGES_PAT }}
+          PAGES_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
         run: |
           echo "Publishing packages to GitHub Package Registry..."
           make publish REGISTRY=github OWNER=${{ github.repository_owner }}
+
+      - name: Save Pages registry cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: dist/registry
+          key: pages-registry-${{ github.run_id }}
 
       - name: Check if static registry was generated
         id: check-registry

--- a/src/unity_wrapper/utils/package_publisher.py
+++ b/src/unity_wrapper/utils/package_publisher.py
@@ -394,18 +394,18 @@ class PackagePublisher:
             # the Pages packument stays current (e.g. on first run after
             # adding PagesPublisher, or after a manual re-publish).
             if registry_dir is not None:
-                real_url = self._fetch_github_tarball_url(
-                    scoped_name, version, headers
-                )
+                pages_base_url = os.getenv("PAGES_BASE_URL")
                 PagesPublisher().update_registry(
                     registry_dir=registry_dir,
                     unscoped_name=original_name,
                     version=version,
                     version_meta=version_meta,
-                    tarball_url=real_url or tarball_url,
+                    tarball_url=tarball_url,
                     shasum=shasum,
                     integrity=integrity,
                     description=pkg_data.get("description"),
+                    tarball_data=tarball_data,
+                    pages_base_url=pages_base_url,
                 )
             raise _PublishConflict(scoped_name)
 
@@ -413,58 +413,19 @@ class PackagePublisher:
         logger.debug(f"GitHub publish HTTP status: {response.status_code}")
 
         if registry_dir is not None:
-            real_url = self._fetch_github_tarball_url(
-                scoped_name, version, headers
-            )
+            pages_base_url = os.getenv("PAGES_BASE_URL")
             PagesPublisher().update_registry(
                 registry_dir=registry_dir,
                 unscoped_name=original_name,
                 version=version,
                 version_meta=version_meta,
-                tarball_url=real_url or tarball_url,
+                tarball_url=tarball_url,
                 shasum=shasum,
                 integrity=integrity,
                 description=pkg_data.get("description"),
+                tarball_data=tarball_data,
+                pages_base_url=pages_base_url,
             )
-
-    def _fetch_github_tarball_url(
-        self,
-        scoped_name: str,
-        version: str,
-        headers: Dict[str, str],
-    ) -> Optional[str]:
-        """Fetch the real tarball URL from GitHub Packages for a version.
-
-        GitHub Packages uses a ``/download/...`` URL format that differs
-        from the standard npm ``/-/name-version.tgz`` path.  This method
-        queries the packument to obtain the authoritative download URL.
-
-        Args:
-            scoped_name: Scoped package name (e.g. ``@owner/com.foo.bar``).
-            version: Version string (e.g. ``1.2.3``).
-            headers: HTTP headers including Bearer auth token.
-
-        Returns:
-            Real tarball URL from GitHub Packages, or ``None`` on failure.
-        """
-        try:
-            url = f"{self.config['url']}/{scoped_name}"
-            resp = http_requests.get(url, headers=headers, timeout=30)
-            resp.raise_for_status()
-            data: Dict[str, Any] = resp.json()
-            tarball: Optional[str] = (
-                data.get("versions", {})
-                .get(version, {})
-                .get("dist", {})
-                .get("tarball")
-            )
-            return tarball
-        except Exception as exc:
-            logger.warning(
-                f"Could not fetch real tarball URL for "
-                f"{scoped_name}@{version}: {exc}"
-            )
-            return None
 
     def _npm_publish(self, package_dir: Path) -> None:
         """Publish package using npm (non-GitHub registries)."""

--- a/src/unity_wrapper/utils/package_publisher.py
+++ b/src/unity_wrapper/utils/package_publisher.py
@@ -18,6 +18,24 @@ from unity_wrapper.utils.pages_publisher import PagesPublisher
 logger = logging.getLogger(__name__)
 
 
+def _get_pages_base_url() -> Optional[str]:
+    """Return a validated PAGES_BASE_URL from the environment.
+
+    Returns ``None`` (and logs a warning) when the variable is absent or
+    blank so callers can fall back to the constructed GitHub Packages URL
+    rather than generating an invalid tarball path.
+    """
+    raw = os.getenv("PAGES_BASE_URL", "")
+    url = raw.strip()
+    if not url:
+        logger.warning(
+            "PAGES_BASE_URL is not set; tarballs will use the GitHub "
+            "Packages URL which requires authentication."
+        )
+        return None
+    return url
+
+
 class _PublishConflict(Exception):
     """Raised when a package version already exists in the registry."""
 
@@ -394,7 +412,7 @@ class PackagePublisher:
             # the Pages packument stays current (e.g. on first run after
             # adding PagesPublisher, or after a manual re-publish).
             if registry_dir is not None:
-                pages_base_url = os.getenv("PAGES_BASE_URL")
+                pages_base_url = _get_pages_base_url()
                 PagesPublisher().update_registry(
                     registry_dir=registry_dir,
                     unscoped_name=original_name,
@@ -413,7 +431,7 @@ class PackagePublisher:
         logger.debug(f"GitHub publish HTTP status: {response.status_code}")
 
         if registry_dir is not None:
-            pages_base_url = os.getenv("PAGES_BASE_URL")
+            pages_base_url = _get_pages_base_url()
             PagesPublisher().update_registry(
                 registry_dir=registry_dir,
                 unscoped_name=original_name,

--- a/src/unity_wrapper/utils/pages_publisher.py
+++ b/src/unity_wrapper/utils/pages_publisher.py
@@ -11,10 +11,14 @@ responses (e.g. ``@klumhru/com.foo.bar``).  Unity Package Manager
 resolve packages whose packument ``name`` field contains a ``@scope/``
 prefix.
 
-By generating static packument files with the correct unscoped name
-and hosting them on GitHub Pages, UPM can resolve packages normally.
-The tarball download URLs still point to GitHub Packages, so the
-existing ``.upmconfig.toml`` token is reused for auth.
+Additionally, GitHub Packages tarball downloads always require
+authentication even for public packages.  UPM cannot apply
+``.upmconfig.toml`` auth to tarball URLs on a different host than the
+configured scopedRegistry, so auth is never sent.
+
+By generating static packument files *and* saving the tarballs to the
+same ``registry_dir``, everything is served from the public GitHub
+Pages site — no authentication required.
 """
 
 import json
@@ -30,10 +34,13 @@ class PagesPublisher:
 
     Each package gets a single JSON file at
     ``{registry_dir}/{package_name}`` (no file extension) following the
-    npm packument
-    format.  Multiple versions accumulate in the same file; the
-    ``dist-tags.latest`` tag always points to the most-recently-added
-    version.
+    npm packument format.  Multiple versions accumulate in the same
+    file; the ``dist-tags.latest`` tag always points to the
+    most-recently-added version.
+
+    When ``tarball_data`` and ``pages_base_url`` are provided, the
+    tarball is written alongside the packument so that UPM can download
+    it directly from the public Pages site — no authentication needed.
 
     Example usage::
 
@@ -42,10 +49,12 @@ class PagesPublisher:
             registry_dir=Path("dist/registry"),
             unscoped_name="com.foo.bar",
             version="1.2.3",
-            version_meta={...},           # npm version object
-            tarball_url="https://...",
+            version_meta={...},
+            tarball_url="https://fallback...",
             shasum="abc123",
             integrity="sha512-...",
+            tarball_data=b"...",
+            pages_base_url="https://owner.github.io/repo",
         )
     """
 
@@ -59,32 +68,58 @@ class PagesPublisher:
         shasum: str,
         integrity: str,
         description: Optional[str] = None,
+        tarball_data: Optional[bytes] = None,
+        pages_base_url: Optional[str] = None,
     ) -> Path:
         """Create or update the static packument file for a package.
 
         If the file already exists, the new version is merged into the
         existing packument and ``dist-tags.latest`` is updated.
 
+        When ``tarball_data`` and ``pages_base_url`` are both provided,
+        the tarball is saved to
+        ``{registry_dir}/{unscoped_name}-{version}.tgz`` and the
+        packument tarball URL is set to the corresponding Pages URL.
+        This makes tarball downloads auth-free for public packages.
+
         Args:
-            registry_dir: Directory where packument JSON files are stored.
+            registry_dir: Directory where packument JSON files are
+                stored.
             unscoped_name: Unscoped UPM package name (e.g.
                 ``com.foo.bar``).
             version: Semver version string (e.g. ``1.2.3``).
             version_meta: npm version metadata dict to embed under the
-                version key.  The ``name`` field will be overwritten with
-                ``unscoped_name``; ``dist`` will be set from the
+                version key.  The ``name`` field will be overwritten
+                with ``unscoped_name``; ``dist`` will be set from the
                 ``tarball_url``, ``shasum``, and ``integrity`` args.
-            tarball_url: Publicly accessible (or auth-gated) tarball URL.
+            tarball_url: Fallback tarball URL used when
+                ``tarball_data``/``pages_base_url`` are not provided.
             shasum: SHA-1 hex digest of the tarball.
             integrity: SRI integrity string (e.g. ``sha512-...``).
             description: Optional human-readable description; used only
                 when creating a new packument file.
+            tarball_data: Raw tarball bytes.  When provided together
+                with ``pages_base_url``, the tarball is saved to the
+                registry directory and the packument URL is updated to
+                point at the Pages host.
+            pages_base_url: Base URL of the GitHub Pages registry (e.g.
+                ``https://owner.github.io/repo``).  Required when
+                ``tarball_data`` is provided.
 
         Returns:
             Path to the written packument JSON file.
         """
         registry_dir.mkdir(parents=True, exist_ok=True)
         packument_path = registry_dir / unscoped_name
+
+        # Save tarball to Pages and use its public URL when possible so
+        # UPM can download without authentication.
+        if tarball_data is not None and pages_base_url is not None:
+            tarball_filename = f"{unscoped_name}-{version}.tgz"
+            tarball_path = registry_dir / tarball_filename
+            tarball_path.write_bytes(tarball_data)
+            tarball_url = f"{pages_base_url.rstrip('/')}/{tarball_filename}"
+            logger.info(f"Saved tarball to Pages registry: {tarball_path}")
 
         packument = self._load_or_create(
             packument_path, unscoped_name, description

--- a/src/unity_wrapper/utils/pages_publisher.py
+++ b/src/unity_wrapper/utils/pages_publisher.py
@@ -114,11 +114,21 @@ class PagesPublisher:
 
         # Save tarball to Pages and use its public URL when possible so
         # UPM can download without authentication.
-        if tarball_data is not None and pages_base_url is not None:
+        pages_base_url_clean = (
+            pages_base_url.strip() if pages_base_url is not None else None
+        )
+        if tarball_data is not None:
+            if not pages_base_url_clean:
+                raise ValueError(
+                    "pages_base_url is required and must be a non-empty "
+                    "string when tarball_data is provided."
+                )
             tarball_filename = f"{unscoped_name}-{version}.tgz"
             tarball_path = registry_dir / tarball_filename
             tarball_path.write_bytes(tarball_data)
-            tarball_url = f"{pages_base_url.rstrip('/')}/{tarball_filename}"
+            tarball_url = (
+                f"{pages_base_url_clean.rstrip('/')}/{tarball_filename}"
+            )
             logger.info(f"Saved tarball to Pages registry: {tarball_path}")
 
         packument = self._load_or_create(

--- a/tests/test_package_publisher.py
+++ b/tests/test_package_publisher.py
@@ -693,3 +693,46 @@ class TestGithubPublishDirect:
                         )
 
         mock_pages.assert_called_once()
+
+
+class TestGetPagesBaseUrl:
+    """_get_pages_base_url normalises the env var and warns when absent."""
+
+    def test_returns_url_when_set(self) -> None:
+        from unity_wrapper.utils.package_publisher import _get_pages_base_url
+
+        with patch.dict(
+            os.environ, {"PAGES_BASE_URL": "https://owner.github.io/repo"}
+        ):
+            assert _get_pages_base_url() == "https://owner.github.io/repo"
+
+    def test_strips_whitespace(self) -> None:
+        from unity_wrapper.utils.package_publisher import _get_pages_base_url
+
+        with patch.dict(
+            os.environ,
+            {"PAGES_BASE_URL": "  https://owner.github.io/repo  "},
+        ):
+            assert _get_pages_base_url() == "https://owner.github.io/repo"
+
+    def test_returns_none_when_unset(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from unity_wrapper.utils.package_publisher import _get_pages_base_url
+
+        env = {k: v for k, v in os.environ.items() if k != "PAGES_BASE_URL"}
+        with patch.dict(os.environ, env, clear=True):
+            with caplog.at_level(logging.WARNING):
+                result = _get_pages_base_url()
+        assert result is None
+        assert "PAGES_BASE_URL" in caplog.text
+
+    def test_returns_none_when_blank(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from unity_wrapper.utils.package_publisher import _get_pages_base_url
+
+        with patch.dict(os.environ, {"PAGES_BASE_URL": "   "}):
+            with caplog.at_level(logging.WARNING):
+                result = _get_pages_base_url()
+        assert result is None

--- a/tests/test_package_publisher.py
+++ b/tests/test_package_publisher.py
@@ -578,6 +578,69 @@ class TestGithubPublishDirect:
         assert call_kwargs["registry_dir"] == registry_dir
 
     @patch("unity_wrapper.utils.package_publisher.http_requests.put")
+    def test_pages_publisher_passes_tarball_data(
+        self, mock_put: MagicMock, tmp_path: Path
+    ) -> None:
+        """tarball_data bytes are forwarded to PagesPublisher."""
+        self._setup_pkg(tmp_path)
+        pub = _make_publisher(registry="github", owner="myorg")
+        mock_put.return_value = MagicMock(status_code=200)
+        registry_dir = tmp_path / "registry"
+        tarball_bytes = b"fake-tarball-content"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="com.foo.bar-1.0.0.tgz\n",
+                stderr="",
+            )
+            with patch("pathlib.Path.read_bytes", return_value=tarball_bytes):
+                with patch(
+                    "unity_wrapper.utils.package_publisher"
+                    ".PagesPublisher.update_registry"
+                ) as mock_pages:
+                    pub._github_publish_direct(
+                        tmp_path, registry_dir=registry_dir
+                    )
+
+        call_kwargs = mock_pages.call_args[1]
+        assert call_kwargs["tarball_data"] == tarball_bytes
+
+    @patch("unity_wrapper.utils.package_publisher.http_requests.put")
+    def test_pages_uses_pages_base_url_from_env(
+        self, mock_put: MagicMock, tmp_path: Path
+    ) -> None:
+        """PAGES_BASE_URL env var is forwarded to PagesPublisher."""
+        self._setup_pkg(tmp_path)
+        pub = _make_publisher(registry="github", owner="myorg")
+        mock_put.return_value = MagicMock(status_code=200)
+        registry_dir = tmp_path / "registry"
+
+        with patch.dict(
+            os.environ,
+            {"PAGES_BASE_URL": "https://myorg.github.io/my-repo"},
+        ):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0,
+                    stdout="com.foo.bar-1.0.0.tgz\n",
+                    stderr="",
+                )
+                with patch("pathlib.Path.read_bytes", return_value=b"x"):
+                    with patch(
+                        "unity_wrapper.utils.package_publisher"
+                        ".PagesPublisher.update_registry"
+                    ) as mock_pages:
+                        pub._github_publish_direct(
+                            tmp_path, registry_dir=registry_dir
+                        )
+
+        call_kwargs = mock_pages.call_args[1]
+        assert call_kwargs["pages_base_url"] == (
+            "https://myorg.github.io/my-repo"
+        )
+
+    @patch("unity_wrapper.utils.package_publisher.http_requests.put")
     def test_pages_publisher_skipped_when_no_registry_dir(
         self, mock_put: MagicMock, tmp_path: Path
     ) -> None:
@@ -630,79 +693,3 @@ class TestGithubPublishDirect:
                         )
 
         mock_pages.assert_called_once()
-
-    @patch("unity_wrapper.utils.package_publisher.http_requests.get")
-    @patch("unity_wrapper.utils.package_publisher.http_requests.put")
-    def test_pages_uses_real_tarball_url_from_github(
-        self,
-        mock_put: MagicMock,
-        mock_get: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        """Pages packument tarball_url comes from GitHub Packages GET."""
-        self._setup_pkg(tmp_path)
-        pub = _make_publisher(registry="github", owner="myorg")
-        mock_put.return_value = MagicMock(status_code=200)
-        real_url = (
-            "https://npm.pkg.github.com/download/"
-            "@myorg/com.foo.bar/1.0.0/abc123"
-        )
-        mock_get.return_value = MagicMock(
-            status_code=200,
-            json=lambda: {
-                "versions": {"1.0.0": {"dist": {"tarball": real_url}}}
-            },
-        )
-        registry_dir = tmp_path / "registry"
-
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=0,
-                stdout="com.foo.bar-1.0.0.tgz\n",
-                stderr="",
-            )
-            with patch("pathlib.Path.read_bytes", return_value=b"x"):
-                with patch(
-                    "unity_wrapper.utils.package_publisher"
-                    ".PagesPublisher.update_registry"
-                ) as mock_pages:
-                    pub._github_publish_direct(
-                        tmp_path, registry_dir=registry_dir
-                    )
-
-        call_kwargs = mock_pages.call_args[1]
-        assert call_kwargs["tarball_url"] == real_url
-
-    @patch("unity_wrapper.utils.package_publisher.http_requests.get")
-    @patch("unity_wrapper.utils.package_publisher.http_requests.put")
-    def test_pages_falls_back_to_constructed_url_when_get_fails(
-        self,
-        mock_put: MagicMock,
-        mock_get: MagicMock,
-        tmp_path: Path,
-    ) -> None:
-        """Falls back to constructed tarball URL when GitHub GET fails."""
-        self._setup_pkg(tmp_path)
-        pub = _make_publisher(registry="github", owner="myorg")
-        mock_put.return_value = MagicMock(status_code=200)
-        mock_get.side_effect = Exception("network error")
-        registry_dir = tmp_path / "registry"
-
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=0,
-                stdout="com.foo.bar-1.0.0.tgz\n",
-                stderr="",
-            )
-            with patch("pathlib.Path.read_bytes", return_value=b"x"):
-                with patch(
-                    "unity_wrapper.utils.package_publisher"
-                    ".PagesPublisher.update_registry"
-                ) as mock_pages:
-                    pub._github_publish_direct(
-                        tmp_path, registry_dir=registry_dir
-                    )
-
-        call_kwargs = mock_pages.call_args[1]
-        # Falls back to constructed /-/ URL
-        assert "/-/" in call_kwargs["tarball_url"]

--- a/tests/test_pages_publisher.py
+++ b/tests/test_pages_publisher.py
@@ -188,3 +188,91 @@ class TestPagesPublisherTarballUrl:
         )
         doc = json.loads((registry_dir / "com.foo.bar").read_text())
         assert doc["versions"]["1.0.0"]["dist"]["tarball"] == expected
+
+
+class TestPagesPublisherTarballStorage:
+    """When tarball_data + pages_base_url are provided, the tarball is
+    saved to the registry dir and the packument uses the Pages URL."""
+
+    def test_tarball_file_written(
+        self,
+        publisher: PagesPublisher,
+        registry_dir: Path,
+    ) -> None:
+        publisher.update_registry(
+            registry_dir=registry_dir,
+            unscoped_name="com.foo.bar",
+            version="1.0.0",
+            version_meta=dict(_VERSION_META),
+            tarball_url="https://fallback/",
+            shasum="abc",
+            integrity="sha512-x==",
+            tarball_data=b"tarball-bytes",
+            pages_base_url="https://owner.github.io/repo",
+        )
+        tarball_path = registry_dir / "com.foo.bar-1.0.0.tgz"
+        assert tarball_path.exists()
+        assert tarball_path.read_bytes() == b"tarball-bytes"
+
+    def test_packument_url_points_to_pages(
+        self,
+        publisher: PagesPublisher,
+        registry_dir: Path,
+    ) -> None:
+        publisher.update_registry(
+            registry_dir=registry_dir,
+            unscoped_name="com.foo.bar",
+            version="1.0.0",
+            version_meta=dict(_VERSION_META),
+            tarball_url="https://fallback/",
+            shasum="abc",
+            integrity="sha512-x==",
+            tarball_data=b"tarball-bytes",
+            pages_base_url="https://owner.github.io/repo",
+        )
+        doc = json.loads((registry_dir / "com.foo.bar").read_text())
+        expected = "https://owner.github.io/repo/com.foo.bar-1.0.0.tgz"
+        assert doc["versions"]["1.0.0"]["dist"]["tarball"] == expected
+
+    def test_pages_base_url_trailing_slash_stripped(
+        self,
+        publisher: PagesPublisher,
+        registry_dir: Path,
+    ) -> None:
+        publisher.update_registry(
+            registry_dir=registry_dir,
+            unscoped_name="com.foo.bar",
+            version="2.0.0",
+            version_meta=dict(_VERSION_META),
+            tarball_url="https://fallback/",
+            shasum="abc",
+            integrity="sha512-x==",
+            tarball_data=b"data",
+            pages_base_url="https://owner.github.io/repo/",
+        )
+        doc = json.loads((registry_dir / "com.foo.bar").read_text())
+        url = doc["versions"]["2.0.0"]["dist"]["tarball"]
+        assert not url.startswith(
+            "https://owner.github.io/repo//"
+        ), "double slash in URL"
+        assert url == "https://owner.github.io/repo/com.foo.bar-2.0.0.tgz"
+
+    def test_fallback_url_used_when_no_tarball_data(
+        self,
+        publisher: PagesPublisher,
+        registry_dir: Path,
+    ) -> None:
+        fallback = "https://npm.pkg.github.com/download/x"
+        publisher.update_registry(
+            registry_dir=registry_dir,
+            unscoped_name="com.foo.bar",
+            version="1.0.0",
+            version_meta=dict(_VERSION_META),
+            tarball_url=fallback,
+            shasum="abc",
+            integrity="sha512-x==",
+            pages_base_url="https://owner.github.io/repo",
+            # tarball_data intentionally omitted
+        )
+        doc = json.loads((registry_dir / "com.foo.bar").read_text())
+        assert doc["versions"]["1.0.0"]["dist"]["tarball"] == fallback

--- a/tests/test_pages_publisher.py
+++ b/tests/test_pages_publisher.py
@@ -276,3 +276,41 @@ class TestPagesPublisherTarballStorage:
         )
         doc = json.loads((registry_dir / "com.foo.bar").read_text())
         assert doc["versions"]["1.0.0"]["dist"]["tarball"] == fallback
+
+    def test_raises_when_tarball_data_without_pages_base_url(
+        self,
+        publisher: PagesPublisher,
+        registry_dir: Path,
+    ) -> None:
+        """Providing tarball_data without a valid pages_base_url raises."""
+        with pytest.raises(ValueError, match="pages_base_url is required"):
+            publisher.update_registry(
+                registry_dir=registry_dir,
+                unscoped_name="com.foo.bar",
+                version="1.0.0",
+                version_meta=dict(_VERSION_META),
+                tarball_url="https://fallback/",
+                shasum="abc",
+                integrity="sha512-x==",
+                tarball_data=b"data",
+                pages_base_url=None,
+            )
+
+    def test_raises_when_tarball_data_with_blank_pages_base_url(
+        self,
+        publisher: PagesPublisher,
+        registry_dir: Path,
+    ) -> None:
+        """Blank pages_base_url with tarball_data raises; no silent bad URL."""
+        with pytest.raises(ValueError, match="pages_base_url is required"):
+            publisher.update_registry(
+                registry_dir=registry_dir,
+                unscoped_name="com.foo.bar",
+                version="1.0.0",
+                version_meta=dict(_VERSION_META),
+                tarball_url="https://fallback/",
+                shasum="abc",
+                integrity="sha512-x==",
+                tarball_data=b"data",
+                pages_base_url="   ",
+            )


### PR DESCRIPTION
## Problem

UPM downloads tarballs from GitHub Packages which always requires auth, even for public packages. UPM doesn't apply `.upmconfig.toml` credentials to tarball URLs on a different host than the configured `scopedRegistry`, so every tarball download fails with 401.

## Solution

Save the tarball bytes directly to `dist/registry/` alongside the packument during publish. GitHub Pages serves both files publicly — no authentication required for open source packages.

### Changes

- **`pages_publisher.py`**: new `tarball_data` + `pages_base_url` params on `update_registry()`; writes tarball to `registry_dir/{name}-{version}.tgz` and uses the Pages URL in the packument
- **`package_publisher.py`**: forwards `tarball_data` bytes and `PAGES_BASE_URL` env to `PagesPublisher`; removes the now-unnecessary `_fetch_github_tarball_url()` method
- **workflow**: restores `dist/registry/` from cache before publish (preserves tarballs from prior runs for packages not rebuilt this run); saves cache after publish; sets `PAGES_BASE_URL` env var
- **tests**: 137 passing (+4 new `TestPagesPublisherTarballStorage` tests; replaced 2 fetch-url tests with 2 tarball-data forwarding tests)