### PR TITLE
feat: add exclude_paths support to package builds

### DIFF
--- a/config/packages.yaml
+++ b/config/packages.yaml
@@ -114,6 +114,12 @@ packages:
     asmdef_name: "UniTask"
     namespace: "Cysharp.Threading.Tasks"
     keywords: ["async", "await", "unity"]
+    # Exclude the External/ subtree: it contains optional TMP, DOTween, and
+    # Addressables extensions that require 3rd-party assemblies not guaranteed
+    # to be present in the consumer project.  Each sub-folder ships its own
+    # .asmdef so there is no risk of stripping required symbols.
+    exclude_paths:
+      - "External"
     # versionDefines are present in the upstream asmdef; they are preserved
     # automatically when the source ships its own UniTask.asmdef.  These
     # extras serve as a fallback if the source asmdef is absent.

--- a/src/unity_wrapper/core/package_builder.py
+++ b/src/unity_wrapper/core/package_builder.py
@@ -92,8 +92,9 @@ class PackageBuilder:
             )
 
         # Organize into Unity package structure
+        exclude_paths: List[str] = package_config.get("exclude_paths", [])
         runtime_dir = self.unity_generator.organize_runtime_structure(
-            source_dir, package_output_dir
+            source_dir, package_output_dir, exclude_paths=exclude_paths
         )
 
         # Generate package.json

--- a/src/unity_wrapper/core/unity_generator.py
+++ b/src/unity_wrapper/core/unity_generator.py
@@ -226,11 +226,62 @@ class UnityGenerator:
 
         return type_mapping.get(suffix, "DefaultAsset")
 
+    @staticmethod
+    def _build_exclude_ignore(root: Path, exclude_paths: List[str]) -> Any:
+        """Return a ``shutil.copytree`` ignore callable.
+
+        Each entry in *exclude_paths* is matched against the name of each
+        item being copied OR against its path relative to *root* (POSIX
+        separators, no leading slash).  A trailing ``/`` in an entry is
+        stripped before matching.
+
+        Examples::
+
+            exclude_paths=["External"]
+            # skips Runtime/External/ wherever it appears
+
+            exclude_paths=["External/TMP"]
+            # skips only Runtime/External/TMP/
+        """
+        normalized = [p.rstrip("/").rstrip("\\") for p in exclude_paths]
+
+        def _ignore(src: str, names: List[str]) -> set:
+            src_path = Path(src)
+            ignored: set = set()
+            for name in names:
+                rel = (src_path / name).relative_to(root)
+                rel_str = rel.as_posix()
+                for excl in normalized:
+                    if (
+                        name == excl
+                        or rel_str == excl
+                        or rel_str.startswith(excl + "/")
+                    ):
+                        ignored.add(name)
+                        break
+            return ignored
+
+        return _ignore
+
     def organize_runtime_structure(
-        self, source_dir: Path, package_dir: Path
+        self,
+        source_dir: Path,
+        package_dir: Path,
+        exclude_paths: Optional[List[str]] = None,
     ) -> Path:
-        """Organize files into Unity package structure with Runtime folder."""
+        """Organize files into Unity package structure with Runtime folder.
+
+        Args:
+            source_dir: Root of the extracted source tree.
+            package_dir: Destination Unity package directory.
+            exclude_paths: Optional list of paths (relative to the Runtime
+                root) or directory names to exclude from the copy.  Trailing
+                slashes are ignored.  For example ``["External"]`` will omit
+                the ``Runtime/External/`` subtree entirely.
+        """
         import shutil
+
+        effective_excludes: List[str] = exclude_paths or []
 
         # Check if source directory already has a Runtime folder
         source_runtime_dir = source_dir / "Runtime"
@@ -242,7 +293,14 @@ class UnityGenerator:
             if runtime_dir.exists():
                 shutil.rmtree(runtime_dir)
 
-            shutil.copytree(source_runtime_dir, runtime_dir)
+            ignore_fn = (
+                self._build_exclude_ignore(
+                    source_runtime_dir, effective_excludes
+                )
+                if effective_excludes
+                else None
+            )
+            shutil.copytree(source_runtime_dir, runtime_dir, ignore=ignore_fn)
 
             # Also copy any other files/folders at the root level
             if source_dir.exists():
@@ -260,30 +318,56 @@ class UnityGenerator:
                                 dirs_exist_ok=True,
                             )
 
-            logger.info(
-                f"Found existing Runtime folder, copied directly to "
-                f"{runtime_dir}"
-            )
+            if effective_excludes:
+                logger.info(
+                    f"Found existing Runtime folder, copied to {runtime_dir}"
+                    f" (excluded: {effective_excludes})"
+                )
+            else:
+                logger.info(
+                    f"Found existing Runtime folder, copied directly to "
+                    f"{runtime_dir}"
+                )
         else:
             # Original behavior: create Runtime folder
             # and copy all content into it
             runtime_dir = package_dir / "Runtime"
             runtime_dir.mkdir(parents=True, exist_ok=True)
 
+            ignore_fn = (
+                self._build_exclude_ignore(source_dir, effective_excludes)
+                if effective_excludes
+                else None
+            )
+
             # Copy all source files to Runtime directory
             if source_dir.exists():
                 for item in source_dir.iterdir():
+                    if ignore_fn and item.name in ignore_fn(
+                        str(source_dir), [item.name]
+                    ):
+                        logger.debug(f"Excluded: {item.name}")
+                        continue
                     if item.is_file():
                         shutil.copy2(item, runtime_dir)
                     elif item.is_dir():
                         shutil.copytree(
-                            item, runtime_dir / item.name, dirs_exist_ok=True
+                            item,
+                            runtime_dir / item.name,
+                            dirs_exist_ok=True,
+                            ignore=ignore_fn,
                         )
 
-            logger.info(
-                f"Organized source files into Runtime structure at "
-                f"{runtime_dir}"
-            )
+            if effective_excludes:
+                logger.info(
+                    f"Organized source files into Runtime structure at "
+                    f"{runtime_dir} (excluded: {effective_excludes})"
+                )
+            else:
+                logger.info(
+                    f"Organized source files into Runtime structure at "
+                    f"{runtime_dir}"
+                )
 
         # Remove C# project files that aren't needed in Unity
         if self._should_remove_csharp_project_files():

--- a/tests/test_unity_generator.py
+++ b/tests/test_unity_generator.py
@@ -118,6 +118,83 @@ def test_organize_runtime_structure_preserves_existing_structure(
     assert (package_dir / "package.json").exists()
 
 
+def test_organize_runtime_structure_exclude_paths_with_existing_runtime(
+    temp_directories: Tuple[Path, Path, Path],
+) -> None:
+    """Test that exclude_paths omits matching dirs when source has Runtime."""
+    source_dir, package_dir, templates_dir = temp_directories
+    generator = UnityGenerator(templates_dir)
+
+    # Build a UniTask-like structure: Runtime/ with External/ subdirectory
+    runtime_source = source_dir / "Runtime"
+    runtime_source.mkdir()
+    (runtime_source / "UniTask.cs").write_text("// core")
+    external_dir = runtime_source / "External"
+    external_dir.mkdir()
+    tmp_dir = external_dir / "TextMeshPro"
+    tmp_dir.mkdir()
+    (tmp_dir / "TMP.cs").write_text("// TMP ext")
+    (external_dir / "DOTween.cs").write_text("// DOTween ext")
+
+    runtime_dir = generator.organize_runtime_structure(
+        source_dir, package_dir, exclude_paths=["External"]
+    )
+
+    assert (runtime_dir / "UniTask.cs").exists()
+    assert not (runtime_dir / "External").exists()
+    assert not (runtime_dir / "External" / "TextMeshPro" / "TMP.cs").exists()
+
+
+def test_organize_runtime_structure_exclude_paths_without_runtime_folder(
+    temp_directories: Tuple[Path, Path, Path],
+) -> None:
+    """Test exclude_paths works when source has no pre-existing Runtime."""
+    source_dir, package_dir, templates_dir = temp_directories
+    generator = UnityGenerator(templates_dir)
+
+    # Source without a Runtime/ folder but with subdirs to exclude
+    (source_dir / "core.cs").write_text("// core")
+    external_dir = source_dir / "External"
+    external_dir.mkdir()
+    (external_dir / "ext.cs").write_text("// ext")
+
+    runtime_dir = generator.organize_runtime_structure(
+        source_dir, package_dir, exclude_paths=["External"]
+    )
+
+    assert (runtime_dir / "core.cs").exists()
+    assert not (runtime_dir / "External").exists()
+
+
+def test_organize_runtime_structure_exclude_nested_path(
+    temp_directories: Tuple[Path, Path, Path],
+) -> None:
+    """Test excluding a nested subdirectory by relative path."""
+    source_dir, package_dir, templates_dir = temp_directories
+    generator = UnityGenerator(templates_dir)
+
+    runtime_source = source_dir / "Runtime"
+    runtime_source.mkdir()
+    (runtime_source / "core.cs").write_text("// core")
+    ext = runtime_source / "External"
+    ext.mkdir()
+    tmp = ext / "TMP"
+    tmp.mkdir()
+    (tmp / "tmp.cs").write_text("// TMP")
+    dotween = ext / "DOTween"
+    dotween.mkdir()
+    (dotween / "dt.cs").write_text("// DOTween")
+
+    # Only exclude External/TMP, keep External/DOTween
+    runtime_dir = generator.organize_runtime_structure(
+        source_dir, package_dir, exclude_paths=["External/TMP"]
+    )
+
+    assert (runtime_dir / "core.cs").exists()
+    assert not (runtime_dir / "External" / "TMP").exists()
+    assert (runtime_dir / "External" / "DOTween" / "dt.cs").exists()
+
+
 class TestGeneratePackageJsonVersion:
     """generate_package_json strips leading 'v' from version strings."""
 


### PR DESCRIPTION
## Summary

Adds an `exclude_paths` field to `packages.yaml` that lets you strip specific directory subtrees from a built package.

### Motivation
UniTask's `Runtime/External/` contains optional TMP, DOTween, and Addressables extensions.  Each ships its own `.asmdef` and requires 3rd-party assemblies that may not be present in the consumer project.  Building the package without them avoids spurious compilation errors.

### How it works
- `exclude_paths` is a list of directory names or relative paths (trailing `/` stripped).  Matching is applied at any depth using `shutil.copytree`'s ignore callback.
- Works for both the "source has Runtime/" and "source has no Runtime/" copy paths.
- Reads the list from `package_config.get('exclude_paths', [])` in `_build_git_package`, so no schema changes are needed.

### Changes
| File | Change |
|---|---|
| `unity_generator.py` | `organize_runtime_structure()` gains optional `exclude_paths` param; `_build_exclude_ignore()` static helper |
| `package_builder.py` | reads `exclude_paths` from config and forwards it |
| `packages.yaml` | `unitask` adds `exclude_paths: ["External"]` |
| `test_unity_generator.py` | 3 new tests |

All 146 tests pass, lint clean.